### PR TITLE
Fix linter warnings in diagnostics and comment reader

### DIFF
--- a/diagnostics.js
+++ b/diagnostics.js
@@ -78,7 +78,7 @@ function getSnippets() {
 }
 
 /* ── helpers ─────────────────────────────────────────────────────── */
-const opLike = /^(\|\>|==?=?|!==?|<=?|>=?|[-+*/%]=?)$/;
+const opLike = /^(\|>|==?=?|!==?|<=?|>=?|[-+*/%]=?)$/;
 const fmtTok = t => {
   const base = `${t.type}(${t.value})`;
   if (t.type === 'ERROR_TOKEN' || t.type.startsWith('INVALID')) return clr('red', base);

--- a/src/lexer/CommentReader.js
+++ b/src/lexer/CommentReader.js
@@ -13,7 +13,7 @@ export function CommentReader(stream, factory) {
     return factory('COMMENT', buf.join(''), start, stream.getPosition());
   }
 
-  /* /* … *​/ */
+  /* /* … *\/ */
   if (next === '*') {
     const buf = ['/', '*'];
     stream.advance(); stream.advance();


### PR DESCRIPTION
## Summary
- fix regex escape in `diagnostics.js`
- clean CommentReader demo comment

## Testing
- `npm run lint`
- `npm test --silent -- --coverage`
- `node diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_b_68568999335c832f9906378b409abbe6