### PR TITLE
[agent] Improve test coverage

### DIFF
--- a/src/utils/diagnostics.js
+++ b/src/utils/diagnostics.js
@@ -11,8 +11,8 @@
 import fs from 'fs';
 import { performance } from 'perf_hooks';
 import { createInterface } from 'readline';
-import { tokenize } from './src/index.js';
-import { LexerEngine } from './src/lexer/LexerEngine.js';
+import { tokenize } from '../index.js';
+import { LexerEngine } from '../lexer/LexerEngine.js';
 
 /* ── ANSI helper ─────────────────────────────────────────────────── */
 const clr = (c, s) =>

--- a/tests/diagnostics.test.js
+++ b/tests/diagnostics.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
+
+async function runDiagnostics(args = [], env = {}) {
+  jest.resetModules();
+  const diagPath = fileURLToPath(new URL('../src/utils/diagnostics.js', import.meta.url));
+  const originalArgv = process.argv.slice();
+  const originalEnv = { ...process.env };
+  process.argv = [process.execPath, diagPath, ...args];
+  Object.assign(process.env, env);
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (msg) => logs.push(msg);
+
+  await import('../src/utils/diagnostics.js');
+
+  console.log = originalLog;
+  process.argv = originalArgv;
+  process.env = originalEnv;
+  return logs;
+}
+
+test('diagnostics CLI prints token details', async () => {
+  const logs = await runDiagnostics(['let x=1;']);
+  expect(logs.some(l => l.includes('KEYWORD(let)'))).toBe(true);
+});
+
+test('diagnostics CLI outputs JSON when requested', async () => {
+  const logs = await runDiagnostics(['let x=1;'], { JSON: '1' });
+  const tokens = JSON.parse(logs[0]);
+  expect(tokens[0].type).toBe('KEYWORD');
+});

--- a/tests/stateUtils.test.js
+++ b/tests/stateUtils.test.js
@@ -1,0 +1,26 @@
+import { saveState, restoreState } from '../src/integration/stateUtils.js';
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { Token } from '../src/lexer/Token.js';
+
+test('saveState with full policy stores input', () => {
+  const stream = new CharStream('abc');
+  const engine = new LexerEngine(stream);
+  const instance = { stream, engine, tokens: [], trivia: [], _deps: { CharStream, LexerEngine, Token } };
+  const state = saveState(instance);
+  expect(state.input).toBe('abc');
+});
+
+test('tail policy stores tail and restores correctly', () => {
+  const stream = new CharStream('hello');
+  stream.setPosition(2);
+  const engine = new LexerEngine(stream);
+  engine.stateInput = 'tail';
+  const instance = { stream, engine, tokens: [], trivia: [], _deps: { CharStream, LexerEngine, Token } };
+  const state = saveState(instance);
+  expect(state.inputTail).toBe('llo');
+
+  const restored = { _deps: { CharStream, LexerEngine, Token } };
+  restoreState(restored, state);
+  expect(restored.stream.input).toBe('llo');
+});


### PR DESCRIPTION
## Summary
- fix incorrect path in diagnostics script
- test diagnostics CLI
- add tests for state serialisation

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6856f778df508331bd2d34e64625972a