### PR TITLE
[agent] test: expand diagnostics and utils coverage

### DIFF
--- a/tests/diagnostics.test.js
+++ b/tests/diagnostics.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
 
 async function runDiagnostics(args = [], env = {}) {
   jest.resetModules();
@@ -30,4 +31,22 @@ test('diagnostics CLI outputs JSON when requested', async () => {
   const logs = await runDiagnostics(['let x=1;'], { JSON: '1' });
   const tokens = JSON.parse(logs[0]);
   expect(tokens[0].type).toBe('KEYWORD');
+});
+// Additional diagnostics coverage
+
+test('diagnostics CLI shows help and exits', () => {
+  const diagPath = fileURLToPath(new URL('../src/utils/diagnostics.js', import.meta.url));
+  const { stdout, status } = spawnSync(process.execPath, [diagPath, '--help'], { encoding: 'utf8' });
+  expect(status).toBe(0);
+  expect(stdout).toContain('usage: diagnostics.js');
+});
+
+test('diagnostics CLI prints debug indices', async () => {
+  const logs = await runDiagnostics(['--debug', 'let x=1;']);
+  expect(logs[0].startsWith('0')).toBe(true);
+});
+
+test('diagnostics CLI shows trivia output', async () => {
+  const logs = await runDiagnostics(['--trivia', '  x;']);
+  expect(logs.some(l => l.includes('lead→'))).toBe(true);
 });

--- a/tests/lexerUtils.test.js
+++ b/tests/lexerUtils.test.js
@@ -1,0 +1,42 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { readUnicodeEscape, consumeIdentifierLike, readDigitsWithUnderscores, readNumberLiteral } from '../src/lexer/utils.js';
+
+describe('lexer utils', () => {
+  test('readUnicodeEscape parses escapes', () => {
+    const stream = new CharStream('\\u{41}');
+    expect(readUnicodeEscape(stream)).toBe('A');
+  });
+
+  test('readUnicodeEscape returns null for invalid', () => {
+    const stream = new CharStream('\\u123');
+    expect(readUnicodeEscape(stream)).toBeNull();
+  });
+
+  test('consumeIdentifierLike handles escapes', () => {
+    const stream = new CharStream('\\u0041bc');
+    expect(consumeIdentifierLike(stream, { allowEscape: true })).toBe('Abc');
+  });
+
+  test('readDigitsWithUnderscores parses underscores', () => {
+    const stream = new CharStream('1_000');
+    const res = readDigitsWithUnderscores(stream, 0);
+    expect(res).toEqual({ value: '1_000', underscoreSeen: true, lastUnderscore: false });
+  });
+
+  test('readDigitsWithUnderscores rejects consecutive underscores', () => {
+    const stream = new CharStream('1__0');
+    expect(readDigitsWithUnderscores(stream, 0)).toBeNull();
+  });
+
+  test('readNumberLiteral parses decimals', () => {
+    const stream = new CharStream('12.34');
+    const result = readNumberLiteral(stream, 0);
+    expect(result.value).toBe('12.34');
+    expect(result.ch).toBeNull();
+  });
+
+  test('readNumberLiteral enforces fraction when required', () => {
+    const stream = new CharStream('1.');
+    expect(readNumberLiteral(stream, 0, true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostics CLI tests for help, debug and trivia
- introduce lexer utils test suite covering Unicode escapes, underscore digits, and decimal numbers

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6856ff9473b083318dfa9a8d32014a34