### PR TITLE
[agent] tighten lint config and tsconfig

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     "no-unused-vars": "warn",
-    "no-console": "off",
+    "no-console": "warn",
+    "semi": ["error", "always"],
   },
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "prepare": "husky",
     "gentree": "node ./.github/workflows/scripts/genTree.js",
     "tree": "npm run gentree",
-	"diag": "node ./src/utils/diagnostics.js",	
-	"diagostics": "npm run diagnostics"
+    "diag": "node ./src/utils/diagnostics.js",
+    "diagostics": "npm run diagnostics",
+    "workflow": "npm run lint && npm test -- --coverage && node tests/benchmarks/lexer.bench.js"
   },
   "keywords": [
     "lexer",

--- a/tests/benchmarks/lexer.bench.js
+++ b/tests/benchmarks/lexer.bench.js
@@ -2,7 +2,8 @@ import { dirname, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { readdirSync, readFileSync } from 'fs';
 import { performance } from 'perf_hooks';
-import { tokenize } from '../../index.js';
+// Import tokenizer from project source.
+import { tokenize } from '../../src/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "allowJs": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "strict": false,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- enforce semicolons and warn on console usage
- enable strict TypeScript checks
- add workflow npm script
- fix benchmark test import path

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `npm run workflow`


------
https://chatgpt.com/codex/tasks/task_e_68570517e1d48331be20aac50040eb0a