### PR TITLE
[agent] increase test coverage

### DIFF
--- a/tests/lexerUtils.test.js
+++ b/tests/lexerUtils.test.js
@@ -100,4 +100,24 @@ describe('lexer utils', () => {
     const pos = consumeKeyword(stream, 'let', { checkPrev: false });
     expect(pos.index).toBe(4);
   });
+
+  test('consumeIdentifierLike rejects starting digit', () => {
+    const stream = new CharStream('1abc');
+    expect(consumeIdentifierLike(stream)).toBeNull();
+  });
+
+  test('consumeIdentifierLike rejects leading hash', () => {
+    const stream = new CharStream('#foo');
+    expect(consumeIdentifierLike(stream)).toBeNull();
+  });
+
+  test('consumeIdentifierLike stops on bad escape in middle', () => {
+    const stream = new CharStream('A\\u00G0c');
+    expect(consumeIdentifierLike(stream, { allowEscape: true })).toBe('A');
+  });
+
+  test('readUnicodeEscape returns null when not starting with escape', () => {
+    const stream = new CharStream('abc');
+    expect(readUnicodeEscape(stream)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- cover more lexer utils cases like digit-start or bad escapes
- check malformed unicode path in diagnostics CLI

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_6857141eb9e883319b11887427c48619