### PR TITLE
[agent] add manual CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read          # checkout + diff


### PR DESCRIPTION
## Summary
- allow triggering GitHub Actions manually via `workflow_dispatch`

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6857284d93b4833189616b768533e681