### PR TITLE
[agent] chore: reduce test duplication

### DIFF
--- a/tests/readers/BinaryReader.test.js
+++ b/tests/readers/BinaryReader.test.js
@@ -1,42 +1,40 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { BinaryReader } from "../../src/lexer/BinaryReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("BinaryReader reads lowercase prefix", () => {
-  const stream = new CharStream("0b1010");
-  const tok = BinaryReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0b1010");
+  const { token, stream } = runReader(BinaryReader, "0b1010");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0b1010");
   expect(stream.getPosition().index).toBe(6);
 });
 
 test("BinaryReader reads uppercase prefix", () => {
-  const stream = new CharStream("0B11");
-  const tok = BinaryReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0B11");
+  const { token, stream } = runReader(BinaryReader, "0B11");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0B11");
   expect(stream.getPosition().index).toBe(4);
 });
 
 test("BinaryReader returns null when not binary", () => {
   const stream = new CharStream("123");
   const pos = stream.getPosition();
-  const tok = BinaryReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(BinaryReader, "123", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("BinaryReader returns null without digits", () => {
   const stream = new CharStream("0b");
   const pos = stream.getPosition();
-  const tok = BinaryReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(BinaryReader, "0b", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("BinaryReader stops before invalid digit", () => {
   const stream = new CharStream("0b1012");
-  const tok = BinaryReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.value).toBe("0b101");
+  const { token } = runReader(BinaryReader, "0b1012", undefined, stream);
+  expect(token.value).toBe("0b101");
   expect(stream.current()).toBe("2");
 });

--- a/tests/readers/HexReader.test.js
+++ b/tests/readers/HexReader.test.js
@@ -1,42 +1,40 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { HexReader } from "../../src/lexer/HexReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("HexReader reads lowercase prefix", () => {
-  const stream = new CharStream("0x1f");
-  const tok = HexReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0x1f");
+  const { token, stream } = runReader(HexReader, "0x1f");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0x1f");
   expect(stream.getPosition().index).toBe(4);
 });
 
 test("HexReader reads uppercase prefix", () => {
-  const stream = new CharStream("0XAF");
-  const tok = HexReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0XAF");
+  const { token, stream } = runReader(HexReader, "0XAF");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0XAF");
   expect(stream.getPosition().index).toBe(4);
 });
 
 test("HexReader returns null when not a hex literal", () => {
   const stream = new CharStream("123");
   const pos = stream.getPosition();
-  const tok = HexReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(HexReader, "123", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("HexReader returns null without digits", () => {
   const stream = new CharStream("0x");
   const pos = stream.getPosition();
-  const tok = HexReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(HexReader, "0x", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("HexReader stops before invalid digit", () => {
   const stream = new CharStream("0x1fg");
-  const tok = HexReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.value).toBe("0x1f");
+  const { token } = runReader(HexReader, "0x1fg", undefined, stream);
+  expect(token.value).toBe("0x1f");
   expect(stream.current()).toBe("g");
 });

--- a/tests/readers/OctalReader.test.js
+++ b/tests/readers/OctalReader.test.js
@@ -1,42 +1,40 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { OctalReader } from "../../src/lexer/OctalReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("OctalReader reads lowercase prefix", () => {
-  const stream = new CharStream("0o755");
-  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0o755");
+  const { token, stream } = runReader(OctalReader, "0o755");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0o755");
   expect(stream.getPosition().index).toBe(5);
 });
 
 test("OctalReader reads uppercase prefix", () => {
-  const stream = new CharStream("0O123");
-  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("0O123");
+  const { token, stream } = runReader(OctalReader, "0O123");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("0O123");
   expect(stream.getPosition().index).toBe(5);
 });
 
 test("OctalReader returns null when not octal", () => {
   const stream = new CharStream("123");
   const pos = stream.getPosition();
-  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(OctalReader, "123", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("OctalReader returns null without digits", () => {
   const stream = new CharStream("0o");
   const pos = stream.getPosition();
-  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
+  const { token } = runReader(OctalReader, "0o", undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("OctalReader stops before non-octal digit", () => {
   const stream = new CharStream("0o7559");
-  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.value).toBe("0o755");
+  const { token } = runReader(OctalReader, "0o7559", undefined, stream);
+  expect(token.value).toBe("0o755");
   expect(stream.current()).toBe("9");
 });

--- a/tests/readers/WhitespaceReader.test.js
+++ b/tests/readers/WhitespaceReader.test.js
@@ -1,10 +1,8 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { WhitespaceReader } from "../../src/lexer/WhitespaceReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("WhitespaceReader reads consecutive spaces", () => {
-  const stream = new CharStream("   abc");
-  const token = WhitespaceReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  const { token, stream } = runReader(WhitespaceReader, "   abc");
   expect(token.type).toBe("WHITESPACE");
   expect(token.value).toBe("   ");
   expect(stream.getPosition().index).toBe(3);
@@ -12,8 +10,7 @@ test("WhitespaceReader reads consecutive spaces", () => {
 });
 
 test("WhitespaceReader handles mixed whitespace characters", () => {
-  const stream = new CharStream(" \t\n\r\v\fabc");
-  const token = WhitespaceReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  const { token, stream } = runReader(WhitespaceReader, " \t\n\r\v\fabc");
   expect(token.type).toBe("WHITESPACE");
   expect(token.value).toBe(" \t\n\r\v\f");
   expect(stream.getPosition().index).toBe(6);

--- a/tests/utils/readerTestUtils.js
+++ b/tests/utils/readerTestUtils.js
@@ -1,0 +1,9 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+
+export function runReader(reader, src, engine, stream) {
+  const str = stream || new CharStream(src);
+  const token = reader(str, (t, v, s, e) => new Token(t, v, s, e), engine);
+  return { token, stream: str };
+}
+


### PR DESCRIPTION
## Summary
- add `runReader` test helper for constructing streams and tokens
- refactor BinaryReader, OctalReader, HexReader and WhitespaceReader tests to use helper

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68574c721f088331992eda8273408144