### PR TITLE
[agent] refactor tests to use helper

### DIFF
--- a/tests/readers/BigIntReader.test.js
+++ b/tests/readers/BigIntReader.test.js
@@ -1,10 +1,10 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { BigIntReader } from "../../src/lexer/BigIntReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
  test("BigIntReader reads bigint literal", () => {
    const stream = new CharStream("123n");
-   const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
    expect(tok.type).toBe("BIGINT");
    expect(tok.value).toBe("123n");
    expect(stream.getPosition().index).toBe(4);
@@ -13,7 +13,7 @@ import { BigIntReader } from "../../src/lexer/BigIntReader.js";
  test("BigIntReader returns null without trailing n", () => {
    const stream = new CharStream("123");
    const pos = stream.getPosition();
-   const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
    expect(tok).toBeNull();
    expect(stream.getPosition()).toEqual(pos);
  });
@@ -21,7 +21,7 @@ import { BigIntReader } from "../../src/lexer/BigIntReader.js";
 test("BigIntReader rejects decimal values", () => {
   const stream = new CharStream("1.0n");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
@@ -29,7 +29,7 @@ test("BigIntReader rejects decimal values", () => {
 test("BigIntReader rejects prefixed binary bigints", () => {
   const stream = new CharStream("0b101n");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
@@ -37,14 +37,14 @@ test("BigIntReader rejects prefixed binary bigints", () => {
 test("BigIntReader rejects hex bigints", () => {
   const stream = new CharStream("0x1Fn");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("BigIntReader stops before trailing digits", () => {
   const stream = new CharStream("1n2");
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok.type).toBe("BIGINT");
   expect(tok.value).toBe("1n");
   expect(stream.current()).toBe("2");
@@ -52,7 +52,7 @@ test("BigIntReader stops before trailing digits", () => {
 
 test("BigIntReader reads bigint with numeric separators", () => {
   const stream = new CharStream("1_000n");
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok.type).toBe("BIGINT");
   expect(tok.value).toBe("1_000n");
   expect(stream.getPosition().index).toBe(6);
@@ -61,7 +61,7 @@ test("BigIntReader reads bigint with numeric separators", () => {
 test("BigIntReader rejects leading underscore", () => {
   const stream = new CharStream("_1n");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
@@ -69,14 +69,14 @@ test("BigIntReader rejects leading underscore", () => {
 test("BigIntReader rejects trailing underscore", () => {
   const stream = new CharStream("1_n");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("BigIntReader handles zero bigint", () => {
   const stream = new CharStream("0n");
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok.type).toBe("BIGINT");
   expect(tok.value).toBe("0n");
   expect(stream.getPosition().index).toBe(2);
@@ -84,7 +84,7 @@ test("BigIntReader handles zero bigint", () => {
 
 test("BigIntReader reads bigint with internal separators", () => {
   const stream = new CharStream("1_2_3n");
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok.type).toBe("BIGINT");
   expect(tok.value).toBe("1_2_3n");
   expect(stream.getPosition().index).toBe(6);
@@ -93,14 +93,14 @@ test("BigIntReader reads bigint with internal separators", () => {
 test("BigIntReader rejects consecutive separators", () => {
   const stream = new CharStream("1__2n");
   const pos = stream.getPosition();
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
 
 test("BigIntReader reads bigint with leading zeros", () => {
   const stream = new CharStream("00n");
-  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
   expect(tok.type).toBe("BIGINT");
   expect(tok.value).toBe("00n");
   expect(stream.getPosition().index).toBe(3);

--- a/tests/readers/DecimalLiteralReader.test.js
+++ b/tests/readers/DecimalLiteralReader.test.js
@@ -1,10 +1,10 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { DecimalLiteralReader } from "../../src/lexer/DecimalLiteralReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("DecimalLiteralReader reads suffix form", () => {
   const stream = new CharStream("123.45m");
-  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
   expect(tok.type).toBe("DECIMAL");
   expect(tok.value).toBe("123.45m");
   expect(stream.getPosition().index).toBe(7);
@@ -12,7 +12,7 @@ test("DecimalLiteralReader reads suffix form", () => {
 
 test("DecimalLiteralReader reads prefix form", () => {
   const stream = new CharStream("0d123.45");
-  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
   expect(tok.type).toBe("DECIMAL");
   expect(tok.value).toBe("0d123.45");
   expect(stream.getPosition().index).toBe(8);
@@ -20,7 +20,7 @@ test("DecimalLiteralReader reads prefix form", () => {
 
 test("DecimalLiteralReader reads integer suffix", () => {
   const stream = new CharStream("42m");
-  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
   expect(tok.type).toBe("DECIMAL");
   expect(tok.value).toBe("42m");
   expect(stream.getPosition().index).toBe(3);
@@ -28,7 +28,7 @@ test("DecimalLiteralReader reads integer suffix", () => {
 
 test("DecimalLiteralReader reads integer prefix", () => {
   const stream = new CharStream("0d123");
-  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
   expect(tok.type).toBe("DECIMAL");
   expect(tok.value).toBe("0d123");
   expect(stream.getPosition().index).toBe(5);
@@ -37,7 +37,7 @@ test("DecimalLiteralReader reads integer prefix", () => {
 test("DecimalLiteralReader returns null when invalid", () => {
   const stream = new CharStream("0d");
   const pos = stream.getPosition();
-  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });

--- a/tests/readers/StringReader.test.js
+++ b/tests/readers/StringReader.test.js
@@ -1,12 +1,10 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { StringReader } from "../../src/lexer/StringReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 import { LexerError } from "../../src/lexer/LexerError.js";
 
 test("StringReader reads double quoted string", () => {
   const src = '"abc"';
-  const stream = new CharStream(src);
-  const token = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(StringReader, src);
   expect(token.type).toBe('STRING');
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -14,8 +12,7 @@ test("StringReader reads double quoted string", () => {
 
 test("StringReader reads single quoted string", () => {
   const src = "'abc'";
-  const stream = new CharStream(src);
-  const token = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(StringReader, src);
   expect(token.type).toBe('STRING');
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -23,24 +20,21 @@ test("StringReader reads single quoted string", () => {
 
 test("StringReader returns LexerError on unterminated", () => {
   const src = '"abc';
-  const stream = new CharStream(src);
-  const result = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: result } = runReader(StringReader, src);
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('UnterminatedString');
 });
 
 test("StringReader handles escapes", () => {
   const src = '"a\\nb"';
-  const stream = new CharStream(src);
-  const token = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(StringReader, src);
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
 
 test("StringReader errors on newline in string", () => {
   const src = '"a\nb"';
-  const stream = new CharStream(src);
-  const result = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: result } = runReader(StringReader, src);
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('UnterminatedString');
 });

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -2,14 +2,11 @@ import { CharStream } from "../../src/lexer/CharStream.js";
 import { Token } from "../../src/lexer/Token.js";
 import { TemplateStringReader } from "../../src/lexer/TemplateStringReader.js";
 import { LexerError } from "../../src/lexer/LexerError.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("TemplateStringReader reads template with interpolation", () => {
   const src = "`template ${expr}`";
-  const stream = new CharStream(src);
-  const token = TemplateStringReader(
-    stream,
-    (type, value, start, end) => new Token(type, value, start, end)
-  );
+  const { token, stream } = runReader(TemplateStringReader, src);
 
   expect(token.type).toBe("TEMPLATE_STRING");
   expect(token.value).toBe(src);
@@ -18,29 +15,22 @@ test("TemplateStringReader reads template with interpolation", () => {
 
 test("TemplateStringReader produces HTML_TEMPLATE_STRING when tagged", () => {
   const src = "`<div>${x}</div>`";
-  const stream = new CharStream(src);
   const engine = { lastToken: new Token("IDENTIFIER", "html", { index: 0 }, { index: 4 }) };
-  const tok = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e), engine);
+  const { token: tok } = runReader(TemplateStringReader, src, engine);
   expect(tok.type).toBe("HTML_TEMPLATE_STRING");
   expect(tok.value).toBe(src);
 });
 
 test("TemplateStringReader returns null for non-backtick start", () => {
   const stream = new CharStream("'not template'");
-  const result = TemplateStringReader(
-    stream,
-    (type, value, start, end) => new Token(type, value, start, end)
-  );
+  const { token: result } = runReader(TemplateStringReader, undefined, undefined, stream);
 
   expect(result).toBeNull();
 });
 
 test("TemplateStringReader returns LexerError on unterminated template", () => {
   const stream = new CharStream('`unterminated');
-  const result = TemplateStringReader(
-    stream,
-    (type, value, start, end) => new Token(type, value, start, end)
-  );
+  const { token: result } = runReader(TemplateStringReader, undefined, undefined, stream);
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('UnterminatedTemplate');
   expect(result.toString()).toContain('line 1, column 0');
@@ -48,61 +38,41 @@ test("TemplateStringReader returns LexerError on unterminated template", () => {
 
 test("TemplateStringReader returns INVALID_TEMPLATE_STRING on bad escape", () => {
   const stream = new CharStream('`bad \\');
-  const result = TemplateStringReader(
-    stream,
-    (type, value, start, end) => new Token(type, value, start, end)
-  );
+  const { token: result } = runReader(TemplateStringReader, undefined, undefined, stream);
   expect(result.type).toBe('INVALID_TEMPLATE_STRING');
 });
 
 test("TemplateStringReader handles escapes and nested braces", () => {
   const src = "`a ${b\\} c}`";
-  const stream = new CharStream(src);
-  const token = TemplateStringReader(
-    stream,
-    (t, v, s, e) => new Token(t, v, s, e)
-  );
+  const { token, stream } = runReader(TemplateStringReader, src);
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
 
 test("TemplateStringReader tracks nested braces", () => {
   const src = "`t ${ {a:{b}} } end`";
-  const stream = new CharStream(src);
-  const token = TemplateStringReader(
-    stream,
-    (t, v, s, e) => new Token(t, v, s, e)
-  );
+  const { token, stream } = runReader(TemplateStringReader, src);
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
 
 test("TemplateStringReader handles multi-line content", () => {
   const src = "`line1\nline2`";
-  const stream = new CharStream(src);
-  const token = TemplateStringReader(
-    stream,
-    (t, v, s, e) => new Token(t, v, s, e)
-  );
+  const { token, stream } = runReader(TemplateStringReader, src);
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
 
 test("TemplateStringReader errors on unterminated expression", () => {
   const src = "`a ${b"; // missing closing brace and backtick
-  const stream = new CharStream(src);
-  const result = TemplateStringReader(
-    stream,
-    (t, v, s, e) => new Token(t, v, s, e)
-  );
+  const { token: result } = runReader(TemplateStringReader, src);
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe("UnterminatedTemplate");
 });
 
 test("TemplateStringReader handles nested template expressions", () => {
   const src = "`a ${`inner ${1}`}`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -110,8 +80,7 @@ test("TemplateStringReader handles nested template expressions", () => {
 
 test("TemplateStringReader handles CRLF line endings", () => {
   const src = "`line1\r\nline2`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -119,15 +88,13 @@ test("TemplateStringReader handles CRLF line endings", () => {
 
 test("TemplateStringReader returns INVALID_TEMPLATE_STRING on escape at EOF", () => {
   const src = "`abc\\"; // backslash at end
-  const stream = new CharStream(src);
-  const result = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: result } = runReader(TemplateStringReader, src);
   expect(result.type).toBe("INVALID_TEMPLATE_STRING");
 });
 
 test("TemplateStringReader handles empty template", () => {
   const src = "``";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(2);
@@ -135,8 +102,7 @@ test("TemplateStringReader handles empty template", () => {
 
 test("TemplateStringReader handles braces inside strings", () => {
   const src = "`a ${ '{' }`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -145,16 +111,14 @@ test("TemplateStringReader handles braces inside strings", () => {
 
 test("TemplateStringReader handles escaped backtick in expression", () => {
   const src = "`a ${`inner \\` backtick`}`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
 });
 
 test("TemplateStringReader allows extra closing brace", () => {
   const src = "`a ${1}} b`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
@@ -162,8 +126,7 @@ test("TemplateStringReader allows extra closing brace", () => {
 
 test("TemplateStringReader handles deeply nested templates", () => {
   const src = "`start ${`level1 ${`level2 ${3}`}`}`";
-  const stream = new CharStream(src);
-  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token: tok, stream } = runReader(TemplateStringReader, src);
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);


### PR DESCRIPTION
## Summary
- reduce duplication in reader tests by using `runReader` helper

## Testing
- `npm run lint --silent`
- `npm test -- --coverage --silent`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_68574e8ca53c8331a7c2e5db38dca467