### PR TITLE
[agent] Reduce test duplication via helper

### DIFF
--- a/tests/readers/BindOperatorReader.test.js
+++ b/tests/readers/BindOperatorReader.test.js
@@ -1,18 +1,17 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { BindOperatorReader } from "../../src/lexer/BindOperatorReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("BindOperatorReader reads :: operator", () => {
-  const stream = new CharStream("::");
-  const tok = BindOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("BIND_OPERATOR");
-  expect(tok.value).toBe("::");
+  const { token } = runReader(BindOperatorReader, "::");
+  expect(token.type).toBe("BIND_OPERATOR");
+  expect(token.value).toBe("::");
 });
 
 test("BindOperatorReader returns null when sequence not matched", () => {
   const stream = new CharStream("?:");
   const pos = stream.getPosition();
-  const tok = BindOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
+  const { token } = runReader(BindOperatorReader, undefined, undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });

--- a/tests/readers/ByteOrderMarkReader.test.js
+++ b/tests/readers/ByteOrderMarkReader.test.js
@@ -1,12 +1,11 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { ByteOrderMarkReader } from "../../src/lexer/ByteOrderMarkReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("ByteOrderMarkReader consumes BOM at file start", () => {
-  const stream = new CharStream("\uFEFFlet a = 1;");
-  const tok = ByteOrderMarkReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("BOM");
-  expect(tok.value).toBe("\uFEFF");
+  const { token, stream } = runReader(ByteOrderMarkReader, "\uFEFFlet a = 1;");
+  expect(token.type).toBe("BOM");
+  expect(token.value).toBe("\uFEFF");
   expect(stream.getPosition().index).toBe(1);
 });
 
@@ -14,7 +13,7 @@ test("ByteOrderMarkReader returns null when not at start", () => {
   const stream = new CharStream("let a = 1;\uFEFF");
   stream.advance();
   const pos = stream.getPosition();
-  const tok = ByteOrderMarkReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
+  const { token } = runReader(ByteOrderMarkReader, undefined, undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });

--- a/tests/readers/CommentReader.test.js
+++ b/tests/readers/CommentReader.test.js
@@ -1,11 +1,9 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { CommentReader } from "../../src/lexer/CommentReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("CommentReader reads // line comment", () => {
   const src = "//hello\n";
-  const stream = new CharStream(src);
-  const token = CommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(CommentReader, src);
   expect(token.type).toBe("COMMENT");
   expect(token.value).toBe("//hello");
   expect(stream.getPosition().index).toBe(7); // position before newline
@@ -13,8 +11,7 @@ test("CommentReader reads // line comment", () => {
 
 test("CommentReader reads /* block comment */", () => {
   const src = "/* block */ rest";
-  const stream = new CharStream(src);
-  const token = CommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(CommentReader, src);
   expect(token.type).toBe("COMMENT");
   expect(token.value).toBe("/* block */");
   expect(stream.getPosition().index).toBe(11);
@@ -22,8 +19,7 @@ test("CommentReader reads /* block comment */", () => {
 
 test("CommentReader handles unterminated block comment at EOF", () => {
   const src = "/* unterminated";
-  const stream = new CharStream(src);
-  const token = CommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(CommentReader, src);
   expect(token.type).toBe("COMMENT");
   expect(token.value).toBe(src);
   expect(stream.eof()).toBe(true);
@@ -31,8 +27,7 @@ test("CommentReader handles unterminated block comment at EOF", () => {
 
 test("CommentReader handles line comment at EOF", () => {
   const src = "// end";
-  const stream = new CharStream(src);
-  const token = CommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(CommentReader, src);
   expect(token.type).toBe("COMMENT");
   expect(token.value).toBe("// end");
   expect(stream.eof()).toBe(true);

--- a/tests/readers/IdentifierReader.test.js
+++ b/tests/readers/IdentifierReader.test.js
@@ -1,10 +1,9 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { IdentifierReader } from "../../src/lexer/IdentifierReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("§4.1 IdentifierReader: reads simple identifier", () => {
-  const stream = new CharStream("abc def");
-  const token = IdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  const { token, stream } = runReader(IdentifierReader, "abc def");
   expect(token.type).toBe("IDENTIFIER");
   expect(token.value).toBe("abc");
   expect(stream.getPosition().index).toBe(3);
@@ -12,5 +11,5 @@ test("§4.1 IdentifierReader: reads simple identifier", () => {
 
 test("§4.1 IdentifierReader: returns null for non-letter start", () => {
   const stream = new CharStream("123");
-  expect(IdentifierReader(stream, ()=>{})).toBeNull();
+  expect(runReader(IdentifierReader, undefined, undefined, stream).token).toBeNull();
 });

--- a/tests/readers/ImportAssertionReader.test.js
+++ b/tests/readers/ImportAssertionReader.test.js
@@ -1,25 +1,23 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { ImportAssertionReader } from "../../src/lexer/ImportAssertionReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("ImportAssertionReader reads assert clause", () => {
-  const stream = new CharStream("assert { type: 'json' }");
-  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("IMPORT_ASSERTION");
-  expect(tok.value).toBe("assert { type: 'json' }");
+  const { token } = runReader(ImportAssertionReader, "assert { type: 'json' }");
+  expect(token.type).toBe("IMPORT_ASSERTION");
+  expect(token.value).toBe("assert { type: 'json' }");
 });
 
 test("ImportAssertionReader reads with colon syntax", () => {
-  const stream = new CharStream("assert: { type: 'json' }");
-  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("IMPORT_ASSERTION");
-  expect(tok.value).toBe("assert: { type: 'json' }");
+  const { token } = runReader(ImportAssertionReader, "assert: { type: 'json' }");
+  expect(token.type).toBe("IMPORT_ASSERTION");
+  expect(token.value).toBe("assert: { type: 'json' }");
 });
 
 test("ImportAssertionReader returns null for non-matching text", () => {
   const stream = new CharStream("assert true");
   const pos = stream.getPosition();
-  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
+  const { token } = runReader(ImportAssertionReader, undefined, undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });

--- a/tests/readers/OperatorReader.test.js
+++ b/tests/readers/OperatorReader.test.js
@@ -1,33 +1,18 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { OperatorReader } from "../../src/lexer/OperatorReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("OperatorReader reads single and multi-char", () => {
-  let stream = new CharStream("== => + -");
-  let token = OperatorReader(stream, (type, value, start, end) => new Token(type, value, start, end));
+  const { token } = runReader(OperatorReader, undefined, undefined, new CharStream("== => + -"));
   expect(token.value).toBe("==");
 });
 
 test("OperatorReader reads new ECMAScript operators", () => {
   const stream = new CharStream("?. ?? ??= ** **= &&= ||=");
-  let token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("?.");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("??");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("??=");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("**");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("**=");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("&&=");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("||=");
+  const expected = ["?.", "??", "??=", "**", "**=", "&&=", "||="];
+  expected.forEach(value => {
+    const { token } = runReader(OperatorReader, undefined, undefined, stream);
+    expect(token.value).toBe(value);
+    stream.advance();
+  });
 });

--- a/tests/readers/SourceMappingURLReader.test.js
+++ b/tests/readers/SourceMappingURLReader.test.js
@@ -1,36 +1,34 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { SourceMappingURLReader } from "../../src/lexer/SourceMappingURLReader.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 test("SourceMappingURLReader reads external map line comment", () => {
   const stream = new CharStream("//# sourceMappingURL=foo.js.map\n");
-  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("SOURCE_MAPPING_URL");
-  expect(tok.value).toBe("foo.js.map");
+  const { token } = runReader(SourceMappingURLReader, undefined, undefined, stream);
+  expect(token.type).toBe("SOURCE_MAPPING_URL");
+  expect(token.value).toBe("foo.js.map");
   expect(stream.current()).toBe("\n");
 });
 
 test("SourceMappingURLReader reads inline data URI", () => {
   const data = "data:application/json;base64,AAAA";
-  const stream = new CharStream(`//# sourceMappingURL=${data}`);
-  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("SOURCE_MAPPING_URL");
-  expect(tok.value).toBe(data);
+  const { token, stream } = runReader(SourceMappingURLReader, `//# sourceMappingURL=${data}`);
+  expect(token.type).toBe("SOURCE_MAPPING_URL");
+  expect(token.value).toBe(data);
   expect(stream.eof()).toBe(true);
 });
 
 test("SourceMappingURLReader reads block comment", () => {
-  const stream = new CharStream("/*# sourceMappingURL=foo.js.map */");
-  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("SOURCE_MAPPING_URL");
-  expect(tok.value).toBe("foo.js.map");
+  const { token, stream } = runReader(SourceMappingURLReader, "/*# sourceMappingURL=foo.js.map */");
+  expect(token.type).toBe("SOURCE_MAPPING_URL");
+  expect(token.value).toBe("foo.js.map");
   expect(stream.eof()).toBe(true);
 });
 
 test("SourceMappingURLReader returns null when not a mapping comment", () => {
   const stream = new CharStream("// just a comment\n");
   const pos = stream.getPosition();
-  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
+  const { token } = runReader(SourceMappingURLReader, undefined, undefined, stream);
+  expect(token).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });


### PR DESCRIPTION
## Summary
- reuse `runReader` helper across several lexer reader tests
- iterate operator spec cases with a loop for clarity

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_68575218a7c08331a0cafe7b860ed438