### PR TITLE
[agent] refactor(test): centralize reader assertions

### DIFF
--- a/tests/readers/BigIntReader.test.js
+++ b/tests/readers/BigIntReader.test.js
@@ -1,107 +1,55 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
 import { BigIntReader } from "../../src/lexer/BigIntReader.js";
-import { runReader } from "../utils/readerTestUtils.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
- test("BigIntReader reads bigint literal", () => {
-   const stream = new CharStream("123n");
-   const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-   expect(tok.type).toBe("BIGINT");
-   expect(tok.value).toBe("123n");
-   expect(stream.getPosition().index).toBe(4);
- });
+test("BigIntReader reads bigint literal", () => {
+  expectToken(BigIntReader, "123n", "BIGINT", "123n", 4);
+});
 
- test("BigIntReader returns null without trailing n", () => {
-   const stream = new CharStream("123");
-   const pos = stream.getPosition();
-   const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-   expect(tok).toBeNull();
-   expect(stream.getPosition()).toEqual(pos);
- });
+test("BigIntReader returns null without trailing n", () => {
+  expectNull(BigIntReader, "123");
+});
 
 test("BigIntReader rejects decimal values", () => {
-  const stream = new CharStream("1.0n");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "1.0n");
 });
 
 test("BigIntReader rejects prefixed binary bigints", () => {
-  const stream = new CharStream("0b101n");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "0b101n");
 });
 
 test("BigIntReader rejects hex bigints", () => {
-  const stream = new CharStream("0x1Fn");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "0x1Fn");
 });
 
 test("BigIntReader stops before trailing digits", () => {
-  const stream = new CharStream("1n2");
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok.type).toBe("BIGINT");
-  expect(tok.value).toBe("1n");
+  const { stream } = expectToken(BigIntReader, "1n2", "BIGINT", "1n", 2);
   expect(stream.current()).toBe("2");
 });
 
 test("BigIntReader reads bigint with numeric separators", () => {
-  const stream = new CharStream("1_000n");
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok.type).toBe("BIGINT");
-  expect(tok.value).toBe("1_000n");
-  expect(stream.getPosition().index).toBe(6);
+  expectToken(BigIntReader, "1_000n", "BIGINT", "1_000n", 6);
 });
 
 test("BigIntReader rejects leading underscore", () => {
-  const stream = new CharStream("_1n");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "_1n");
 });
 
 test("BigIntReader rejects trailing underscore", () => {
-  const stream = new CharStream("1_n");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "1_n");
 });
 
 test("BigIntReader handles zero bigint", () => {
-  const stream = new CharStream("0n");
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok.type).toBe("BIGINT");
-  expect(tok.value).toBe("0n");
-  expect(stream.getPosition().index).toBe(2);
+  expectToken(BigIntReader, "0n", "BIGINT", "0n", 2);
 });
 
 test("BigIntReader reads bigint with internal separators", () => {
-  const stream = new CharStream("1_2_3n");
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok.type).toBe("BIGINT");
-  expect(tok.value).toBe("1_2_3n");
-  expect(stream.getPosition().index).toBe(6);
+  expectToken(BigIntReader, "1_2_3n", "BIGINT", "1_2_3n", 6);
 });
 
 test("BigIntReader rejects consecutive separators", () => {
-  const stream = new CharStream("1__2n");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(BigIntReader, "1__2n");
 });
 
 test("BigIntReader reads bigint with leading zeros", () => {
-  const stream = new CharStream("00n");
-  const { token: tok } = runReader(BigIntReader, undefined, undefined, stream);
-  expect(tok.type).toBe("BIGINT");
-  expect(tok.value).toBe("00n");
-  expect(stream.getPosition().index).toBe(3);
+  expectToken(BigIntReader, "00n", "BIGINT", "00n", 3);
 });

--- a/tests/readers/DecimalLiteralReader.test.js
+++ b/tests/readers/DecimalLiteralReader.test.js
@@ -1,43 +1,22 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
 import { DecimalLiteralReader } from "../../src/lexer/DecimalLiteralReader.js";
-import { runReader } from "../utils/readerTestUtils.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("DecimalLiteralReader reads suffix form", () => {
-  const stream = new CharStream("123.45m");
-  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
-  expect(tok.type).toBe("DECIMAL");
-  expect(tok.value).toBe("123.45m");
-  expect(stream.getPosition().index).toBe(7);
+  expectToken(DecimalLiteralReader, "123.45m", "DECIMAL", "123.45m", 7);
 });
 
 test("DecimalLiteralReader reads prefix form", () => {
-  const stream = new CharStream("0d123.45");
-  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
-  expect(tok.type).toBe("DECIMAL");
-  expect(tok.value).toBe("0d123.45");
-  expect(stream.getPosition().index).toBe(8);
+  expectToken(DecimalLiteralReader, "0d123.45", "DECIMAL", "0d123.45", 8);
 });
 
 test("DecimalLiteralReader reads integer suffix", () => {
-  const stream = new CharStream("42m");
-  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
-  expect(tok.type).toBe("DECIMAL");
-  expect(tok.value).toBe("42m");
-  expect(stream.getPosition().index).toBe(3);
+  expectToken(DecimalLiteralReader, "42m", "DECIMAL", "42m", 3);
 });
 
 test("DecimalLiteralReader reads integer prefix", () => {
-  const stream = new CharStream("0d123");
-  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
-  expect(tok.type).toBe("DECIMAL");
-  expect(tok.value).toBe("0d123");
-  expect(stream.getPosition().index).toBe(5);
+  expectToken(DecimalLiteralReader, "0d123", "DECIMAL", "0d123", 5);
 });
 
 test("DecimalLiteralReader returns null when invalid", () => {
-  const stream = new CharStream("0d");
-  const pos = stream.getPosition();
-  const { token: tok } = runReader(DecimalLiteralReader, undefined, undefined, stream);
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(DecimalLiteralReader, "0d");
 });

--- a/tests/readers/NumberReader.test.js
+++ b/tests/readers/NumberReader.test.js
@@ -1,30 +1,16 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { NumberReader } from "../../src/lexer/NumberReader.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("NumberReader reads integer and decimal", () => {
-  let stream = new CharStream("123 456.78");
-  let token = NumberReader(stream, (type, value, start, end) => new Token(type, value, start, end));
-  expect(token.type).toBe("NUMBER");
-  expect(token.value).toBe("123");
+  let { stream } = expectToken(NumberReader, "123 456.78", "NUMBER", "123", 3);
   stream.advance(); // skip space
-  token = NumberReader(stream, (type, value, start, end) => new Token(type, value, start, end));
-  expect(token.type).toBe("NUMBER");
-  expect(token.value).toBe("456.78");
+  expectToken(NumberReader, undefined, "NUMBER", "456.78", 10, stream);
 });
 
 test("NumberReader handles trailing decimal point", () => {
-  const stream = new CharStream("123.");
-  const token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(token.type).toBe("NUMBER");
-  expect(token.value).toBe("123.");
-  expect(stream.getPosition().index).toBe(4);
+  expectToken(NumberReader, "123.", "NUMBER", "123.", 4);
 });
 
 test("NumberReader returns null when not starting with digit", () => {
-  const stream = new CharStream(".5");
-  const pos = stream.getPosition();
-  const token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(token).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(NumberReader, ".5");
 });

--- a/tests/readers/NumericSeparatorReader.test.js
+++ b/tests/readers/NumericSeparatorReader.test.js
@@ -1,67 +1,36 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { NumericSeparatorReader } from "../../src/lexer/NumericSeparatorReader.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("NumericSeparatorReader reads underscores", () => {
-  const stream = new CharStream("1_000");
-  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1_000");
-  expect(stream.getPosition().index).toBe(5);
+  expectToken(NumericSeparatorReader, "1_000", "NUMBER", "1_000", 5);
 });
 
 test("NumericSeparatorReader returns null without underscores", () => {
-  const stream = new CharStream("1234");
-  const index = stream.getPosition().index;
-  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition().index).toBe(index);
+  expectNull(NumericSeparatorReader, "1234");
 });
 
 test("NumericSeparatorReader rejects trailing underscore", () => {
-  const stream = new CharStream("1_000_");
-  const index = stream.getPosition().index;
-  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition().index).toBe(index);
+  expectNull(NumericSeparatorReader, "1_000_");
 });
 
 test("NumericSeparatorReader rejects consecutive underscores", () => {
-  const stream = new CharStream("1__0");
-  const index = stream.getPosition().index;
-  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition().index).toBe(index);
+  expectNull(NumericSeparatorReader, "1__0");
 });
 
 test("NumericSeparatorReader stops at non-digit", () => {
-  const stream = new CharStream("1_2a");
-  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1_2");
-  expect(stream.getPosition().index).toBe(3);
+  expectToken(NumericSeparatorReader, "1_2a", "NUMBER", "1_2", 3);
 });
 
 test("NumericSeparatorReader rejects leading underscore", () => {
-  const stream = new CharStream("_1");
-  const pos = stream.getPosition();
-  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(NumericSeparatorReader, "_1");
 });
 
 test("NumericSeparatorReader stops before decimal point", () => {
-  const stream = new CharStream("1_000.5");
-  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1_000");
+  const { stream } = expectToken(NumericSeparatorReader, "1_000.5", "NUMBER", "1_000", 5);
   expect(stream.current()).toBe(".");
 });
 
 test("NumericSeparatorReader stops before exponent", () => {
-  const stream = new CharStream("1_0e5");
-  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1_0");
+  const { stream } = expectToken(NumericSeparatorReader, "1_0e5", "NUMBER", "1_0", 3);
   expect(stream.current()).toBe("e");
 });

--- a/tests/utils/readerTestUtils.js
+++ b/tests/utils/readerTestUtils.js
@@ -7,3 +7,22 @@ export function runReader(reader, src, engine, stream) {
   return { token, stream: str };
 }
 
+export function expectToken(reader, src, type, value, index = value.length, stream) {
+  const { token, stream: str } = runReader(reader, src, undefined, stream);
+  expect(token.type).toBe(type);
+  expect(token.value).toBe(value);
+  expect(str.getPosition().index).toBe(index);
+  return { token, stream: str };
+}
+
+export function expectNull(reader, srcOrStream) {
+  const stream = srcOrStream instanceof CharStream
+    ? srcOrStream
+    : new CharStream(srcOrStream);
+  const pos = stream.getPosition();
+  const { token } = runReader(reader, undefined, undefined, stream);
+  expect(token).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+  return { token, stream };
+}
+


### PR DESCRIPTION
## Summary
- add `expectToken` and `expectNull` helpers
- refactor reader tests to use helpers

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_68575218a7c08331a0cafe7b860ed438