### PR TITLE
[agent] refactor(tests): reduce duplication with token helpers

### DIFF
--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { fileURLToPath } from 'url';
 import { tokenize } from '../src/index.js';
+import { ASSIGNMENT_TYPES, getTypes } from './utils/tokenTypeUtils.js';
 
 /**
  * Helper to execute the CLI entry with mocked process args.
@@ -37,9 +38,7 @@ async function runCli(args) {
 test('CLI prints tokens array for valid input', async () => {
   const result = await runCli(['let x=1;']);
   expect(Array.isArray(result.logs[0])).toBe(true);
-  expect(result.logs[0].map(t => t.type)).toEqual([
-    'KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION'
-  ]);
+  expect(getTypes(result.logs[0])).toEqual(ASSIGNMENT_TYPES);
   expect(result.exitCode).toBeUndefined();
 });
 

--- a/tests/incremental.test.js
+++ b/tests/incremental.test.js
@@ -1,31 +1,20 @@
 import { IncrementalLexer } from '../src/integration/IncrementalLexer.js';
+import { ASSIGNMENT_TYPES, getTypes } from './utils/tokenTypeUtils.js';
 
 test('incremental lexer emits tokens as chunks are fed', () => {
   const types = [];
   const lexer = new IncrementalLexer({ onToken: t => types.push(t.type) });
   lexer.feed('let x');
   lexer.feed(' = 1;');
-  expect(types).toEqual([
-    'KEYWORD',
-    'IDENTIFIER',
-    'OPERATOR',
-    'NUMBER',
-    'PUNCTUATION'
-  ]);
+  expect(types).toEqual(ASSIGNMENT_TYPES);
 });
 
 test('getTokens returns accumulated tokens', () => {
   const lexer = new IncrementalLexer();
   lexer.feed('let a');
   lexer.feed(' = 2;');
-  const types = lexer.getTokens().map(t => t.type);
-  expect(types).toEqual([
-    'KEYWORD',
-    'IDENTIFIER',
-    'OPERATOR',
-    'NUMBER',
-    'PUNCTUATION'
-  ]);
+  const types = getTypes(lexer.getTokens());
+  expect(types).toEqual(ASSIGNMENT_TYPES);
 });
 
 test('feeding whitespace only produces no tokens', () => {
@@ -43,12 +32,6 @@ test('saveState/restoreState resumes lexing', () => {
   resumed.restoreState(state);
   resumed.feed(' = 1;');
 
-  const types = resumed.getTokens().map(t => t.type);
-  expect(types).toEqual([
-    'KEYWORD',
-    'IDENTIFIER',
-    'OPERATOR',
-    'NUMBER',
-    'PUNCTUATION'
-  ]);
+  const types = getTypes(resumed.getTokens());
+  expect(types).toEqual(ASSIGNMENT_TYPES);
 });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,26 +1,15 @@
 import { tokenize } from "../src/index.js";
+import { ASSIGNMENT_TYPES, expectTypes } from "./utils/tokenTypeUtils.js";
 
 test("integration: var declaration", () => {
   const toks = tokenize("let x = 5;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
 });
 
 test("integration: trailing whitespace does not produce null token", () => {
   const toks = tokenize("let x = 5;   ");
   expect(toks).not.toContain(null);
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
 });
 
 test("integration: tokenize returns INVALID_REGEX token on unterminated regex", () => {
@@ -49,13 +38,7 @@ test("integration: bigint and optional chaining", () => {
 
 test("integration: hex literals", () => {
   const toks = tokenize("let n = 0x1A;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
   expect(toks[3].value).toBe("0x1A");
 });
 
@@ -73,49 +56,25 @@ test("integration: numeric separator with exponent splits tokens", () => {
 
 test("integration: binary literal", () => {
   const toks = tokenize("let n = 0b1010;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
   expect(toks[3].value).toBe("0b1010");
 });
 
 test("integration: octal literal", () => {
   const toks = tokenize("let n = 0o755;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
   expect(toks[3].value).toBe("0o755");
 });
 
 test("integration: exponent literal", () => {
   const toks = tokenize("let n = 1e3;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
   expect(toks[3].value).toBe("1e3");
 });
 
 test("integration: unicode identifiers", () => {
   const toks = tokenize("let πδ = 1;");
-  expect(toks.map(t => t.type)).toEqual([
-    "KEYWORD",
-    "IDENTIFIER",
-    "OPERATOR",
-    "NUMBER",
-    "PUNCTUATION"
-  ]);
+  expectTypes(toks, ASSIGNMENT_TYPES);
   expect(toks[1].value).toBe("πδ");
 });
 

--- a/tests/tokenStream.test.js
+++ b/tests/tokenStream.test.js
@@ -1,17 +1,12 @@
 import { createTokenStream } from '../src/integration/TokenStream.js';
+import { ASSIGNMENT_TYPES } from './utils/tokenTypeUtils.js';
 
 test('token stream emits tokens sequentially', done => {
   const stream = createTokenStream('let x = 1;');
   const types = [];
   stream.on('data', t => types.push(t.type));
   stream.on('end', () => {
-    expect(types).toEqual([
-      'KEYWORD',
-      'IDENTIFIER',
-      'OPERATOR',
-      'NUMBER',
-      'PUNCTUATION'
-    ]);
+    expect(types).toEqual(ASSIGNMENT_TYPES);
     done();
   });
 });

--- a/tests/utils/tokenTypeUtils.js
+++ b/tests/utils/tokenTypeUtils.js
@@ -1,0 +1,18 @@
+export const ASSIGNMENT_TYPES = [
+  'KEYWORD',
+  'IDENTIFIER',
+  'OPERATOR',
+  'NUMBER',
+  'PUNCTUATION'
+];
+
+export const PREFIX_TYPES = ASSIGNMENT_TYPES.slice(0, 3);
+export const STRING_ASSIGN_TYPES = [...PREFIX_TYPES, 'STRING', 'PUNCTUATION'];
+export const COMMENT_ASSIGN_TYPES = ['COMMENT', ...ASSIGNMENT_TYPES];
+
+export function getTypes(tokens) {
+  return tokens.map(t => t.type);
+}
+export function expectTypes(tokens, expected) {
+  expect(getTypes(tokens)).toEqual(expected);
+}


### PR DESCRIPTION
## Summary
- add shared token type helpers
- use helpers in incremental and integration tests
- streamline buffered lexer and CLI tests
- simplify token stream expectations

## Testing
- `npm run lint --silent`
- `npm test --silent -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_68575673dc2083318d3037e4709889bd