### PR TITLE
[agent] Refactor reader tests with shared helpers

### DIFF
--- a/tests/readers/FunctionSentReader.test.js
+++ b/tests/readers/FunctionSentReader.test.js
@@ -1,28 +1,18 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { FunctionSentReader } from "../../src/lexer/FunctionSentReader.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("FunctionSentReader reads function.sent", () => {
-  const stream = new CharStream("function.sent");
-  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("FUNCTION_SENT");
-  expect(tok.value).toBe("function.sent");
+  expectToken(FunctionSentReader, "function.sent", "FUNCTION_SENT", "function.sent", 13);
 });
 
 test("FunctionSentReader returns null when sequence not matched", () => {
-  const stream = new CharStream("function.send");
-  const pos = stream.getPosition();
-  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(FunctionSentReader, "function.send");
 });
 
 test("FunctionSentReader returns null inside identifier", () => {
   const stream = new CharStream("myfunction.sent");
   stream.advance();
   stream.advance();
-  const pos = stream.getPosition();
-  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(FunctionSentReader, stream);
 });

--- a/tests/readers/JSXReader.test.js
+++ b/tests/readers/JSXReader.test.js
@@ -1,49 +1,40 @@
 import { jest } from "@jest/globals";
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { JSXReader } from "../../src/lexer/JSXReader.js";
 import { LexerError } from "../../src/lexer/LexerError.js";
+import { runReader } from "../utils/readerTestUtils.js";
 
 const dummyEngine = { popMode() {} };
 
 test("JSXReader reads simple element", () => {
-  const src = '<div>';
-  const stream = new CharStream(src);
-  const token = JSXReader(stream, (t,v,s,e) => new Token(t,v,s,e), dummyEngine);
+  const { token, stream } = runReader(JSXReader, '<div>', dummyEngine);
   expect(token.type).toBe('JSX_TEXT');
-  expect(token.value).toBe(src);
-  expect(stream.getPosition().index).toBe(src.length);
+  expect(token.value).toBe('<div>');
+  expect(stream.getPosition().index).toBe(5);
 });
 
 test("JSXReader handles quoted attributes", () => {
   const src = '<div class="a">';
-  const stream = new CharStream(src);
-  const token = JSXReader(stream, (t,v,s,e) => new Token(t,v,s,e), dummyEngine);
+  const { token, stream } = runReader(JSXReader, src, dummyEngine);
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
 
 test("JSXReader tracks nested elements", () => {
-  const src = '<div><span>';
-  const stream = new CharStream(src);
-  const token = JSXReader(stream, (t,v,s,e) => new Token(t,v,s,e), dummyEngine);
+  const { token, stream } = runReader(JSXReader, '<div><span>', dummyEngine);
   expect(token.value).toBe('<div>');
   expect(stream.getPosition().index).toBe(5);
 });
 
 test("JSXReader returns LexerError on unterminated", () => {
-  const src = '<div';
-  const stream = new CharStream(src);
-  const result = JSXReader(stream, (t,v,s,e) => new Token(t,v,s,e), dummyEngine);
-  expect(result).toBeInstanceOf(LexerError);
-  expect(result.type).toBe('UnterminatedJSX');
+  const { token } = runReader(JSXReader, '<div', dummyEngine);
+  expect(token).toBeInstanceOf(LexerError);
+  expect(token.type).toBe('UnterminatedJSX');
 });
 
 test("JSXReader handles escaped quotes and calls popMode", () => {
   const src = '<div class="a\\"b">';
-  const stream = new CharStream(src);
   const engine = { popMode: jest.fn() };
-  const token = JSXReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  const { token, stream } = runReader(JSXReader, src, engine);
   expect(token.value).toBe(src);
   expect(engine.popMode).toHaveBeenCalled();
   expect(stream.getPosition().index).toBe(src.length);

--- a/tests/readers/UsingStatementReader.test.js
+++ b/tests/readers/UsingStatementReader.test.js
@@ -1,43 +1,27 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { UsingStatementReader } from "../../src/lexer/UsingStatementReader.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
-test("UsingStatementReader reads using", () => {
-  const stream = new CharStream("using x");
-  const tok = UsingStatementReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("USING");
-  expect(tok.value).toBe("using");
-  expect(stream.getPosition().index).toBe(5);
-});
-
-test("UsingStatementReader reads await using", () => {
-  const stream = new CharStream("await using x");
-  const tok = UsingStatementReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("AWAIT_USING");
-  expect(tok.value).toBe("await using");
-  expect(stream.getPosition().index).toBe(11);
+test.each([
+  ["using x", "USING", "using", 5],
+  ["await using x", "AWAIT_USING", "await using", 11]
+])("UsingStatementReader reads %s", (src, type, value, index) => {
+  expectToken(UsingStatementReader, src, type, value, index);
 });
 
 test("UsingStatementReader returns null inside identifier", () => {
   const stream = new CharStream("abusing");
   stream.advance();
   stream.advance();
-  const pos = stream.getPosition();
-  const tok = UsingStatementReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(UsingStatementReader, stream);
 });
 
 test('UsingStatementReader fails for "await" not followed by whitespace', () => {
-  const stream = new CharStream('await;');
-  const tok = UsingStatementReader(stream, () => {});
-  expect(tok).toBeNull();
+  const { stream } = expectNull(UsingStatementReader, 'await;');
   expect(stream.getPosition().index).toBe(0);
 });
 
 test('UsingStatementReader resets when await not followed by using', () => {
-  const stream = new CharStream('await foo');
-  const tok = UsingStatementReader(stream, () => {});
-  expect(tok).toBeNull();
+  const { stream } = expectNull(UsingStatementReader, 'await foo');
   expect(stream.getPosition().index).toBe(0);
 });


### PR DESCRIPTION
## Summary
- refactor `JSXReader`, `UsingStatementReader`, and `FunctionSentReader` tests
- consolidate duplicate token setup via shared utilities

## Testing
- `npm run lint --silent`
- `npm test --silent -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_68575a53feb883318202455df1a90094