### PR TITLE
[agent] test: flatten BigIntReader cases

### DIFF
--- a/tests/readers/BigIntReader.test.js
+++ b/tests/readers/BigIntReader.test.js
@@ -1,55 +1,33 @@
 import { BigIntReader } from "../../src/lexer/BigIntReader.js";
 import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
-test("BigIntReader reads bigint literal", () => {
-  expectToken(BigIntReader, "123n", "BIGINT", "123n", 4);
+const tokenCases = [
+  ["reads bigint literal", "123n", "BIGINT", "123n", 4],
+  ["reads bigint with numeric separators", "1_000n", "BIGINT", "1_000n", 6],
+  ["handles zero bigint", "0n", "BIGINT", "0n", 2],
+  ["reads bigint with internal separators", "1_2_3n", "BIGINT", "1_2_3n", 6],
+  ["reads bigint with leading zeros", "00n", "BIGINT", "00n", 3],
+];
+
+test.each(tokenCases)("BigIntReader %s", (_desc, src, type, value, index) => {
+  expectToken(BigIntReader, src, type, value, index);
 });
 
-test("BigIntReader returns null without trailing n", () => {
-  expectNull(BigIntReader, "123");
-});
+const nullCases = [
+  ["returns null without trailing n", "123"],
+  ["rejects decimal values", "1.0n"],
+  ["rejects prefixed binary bigints", "0b101n"],
+  ["rejects hex bigints", "0x1Fn"],
+  ["rejects leading underscore", "_1n"],
+  ["rejects trailing underscore", "1_n"],
+  ["rejects consecutive separators", "1__2n"],
+];
 
-test("BigIntReader rejects decimal values", () => {
-  expectNull(BigIntReader, "1.0n");
-});
-
-test("BigIntReader rejects prefixed binary bigints", () => {
-  expectNull(BigIntReader, "0b101n");
-});
-
-test("BigIntReader rejects hex bigints", () => {
-  expectNull(BigIntReader, "0x1Fn");
+test.each(nullCases)("BigIntReader %s", (_desc, src) => {
+  expectNull(BigIntReader, src);
 });
 
 test("BigIntReader stops before trailing digits", () => {
   const { stream } = expectToken(BigIntReader, "1n2", "BIGINT", "1n", 2);
   expect(stream.current()).toBe("2");
-});
-
-test("BigIntReader reads bigint with numeric separators", () => {
-  expectToken(BigIntReader, "1_000n", "BIGINT", "1_000n", 6);
-});
-
-test("BigIntReader rejects leading underscore", () => {
-  expectNull(BigIntReader, "_1n");
-});
-
-test("BigIntReader rejects trailing underscore", () => {
-  expectNull(BigIntReader, "1_n");
-});
-
-test("BigIntReader handles zero bigint", () => {
-  expectToken(BigIntReader, "0n", "BIGINT", "0n", 2);
-});
-
-test("BigIntReader reads bigint with internal separators", () => {
-  expectToken(BigIntReader, "1_2_3n", "BIGINT", "1_2_3n", 6);
-});
-
-test("BigIntReader rejects consecutive separators", () => {
-  expectNull(BigIntReader, "1__2n");
-});
-
-test("BigIntReader reads bigint with leading zeros", () => {
-  expectToken(BigIntReader, "00n", "BIGINT", "00n", 3);
 });


### PR DESCRIPTION
## Summary
- simplify BigIntReader tests with `test.each`

## Testing
- `npm run lint --silent`
- `npm test --silent -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_68575d80e87c8331812a46734cdd1060