### PR TITLE
[agent] test: flatten reader tests using helpers

### DIFF
--- a/tests/readers/ByteOrderMarkReader.test.js
+++ b/tests/readers/ByteOrderMarkReader.test.js
@@ -1,19 +1,21 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
 import { ByteOrderMarkReader } from "../../src/lexer/ByteOrderMarkReader.js";
-import { runReader } from "../utils/readerTestUtils.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("ByteOrderMarkReader consumes BOM at file start", () => {
-  const { token, stream } = runReader(ByteOrderMarkReader, "\uFEFFlet a = 1;");
-  expect(token.type).toBe("BOM");
-  expect(token.value).toBe("\uFEFF");
-  expect(stream.getPosition().index).toBe(1);
+  const { stream } = expectToken(
+    ByteOrderMarkReader,
+    "\uFEFFlet a = 1;",
+    "BOM",
+    "\uFEFF",
+    1
+  );
+  // ensure other chars remain unread
+  expect(stream.current()).toBe("l");
 });
 
 test("ByteOrderMarkReader returns null when not at start", () => {
   const stream = new CharStream("let a = 1;\uFEFF");
   stream.advance();
-  const pos = stream.getPosition();
-  const { token } = runReader(ByteOrderMarkReader, undefined, undefined, stream);
-  expect(token).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(ByteOrderMarkReader, stream);
 });

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -1,68 +1,24 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { ExponentReader } from "../../src/lexer/ExponentReader.js";
+import { expectToken, expectNull, runReader } from "../utils/readerTestUtils.js";
 
-test("ExponentReader reads simple exponent", () => {
-  const stream = new CharStream("1e3");
-  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1e3");
-  expect(stream.getPosition().index).toBe(3);
+test.each([
+  ["1e3", 3],
+  ["3.5E+2", 6],
+  ["2e-3", 4],
+  ["1.e2", 4]
+])("ExponentReader reads %s", (src, index) => {
+  expectToken(ExponentReader, src, "NUMBER", src, index);
 });
 
-test("ExponentReader reads decimal exponent with sign", () => {
-  const stream = new CharStream("3.5E+2");
-  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("3.5E+2");
-  expect(stream.getPosition().index).toBe(6);
+test.each(["2e+", "123", "1e+"])('ExponentReader returns null for %s', (src) => {
+  expectNull(ExponentReader, src);
 });
 
-test("ExponentReader reads negative exponent", () => {
-  const stream = new CharStream("2e-3");
-  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("2e-3");
-  expect(stream.getPosition().index).toBe(4);
-});
-
-test("ExponentReader returns null when missing digits", () => {
-  const stream = new CharStream("2e+");
-  const pos = stream.getPosition();
-  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
-});
-
-test("ExponentReader returns null when no exponent", () => {
-  const stream = new CharStream("123");
-  const pos = stream.getPosition();
-  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
-});
 
 
 test("ExponentReader stops before second exponent", () => {
-  const stream = new CharStream("1e10e2");
-  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1e10");
+  const { token, stream } = runReader(ExponentReader, "1e10e2");
+  expect(token.type).toBe("NUMBER");
+  expect(token.value).toBe("1e10");
   expect(stream.current()).toBe("e");
-});
-
-test("ExponentReader reads digit-dot-exponent form", () => {
-  const stream = new CharStream("1.e2");
-  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok.type).toBe("NUMBER");
-  expect(tok.value).toBe("1.e2");
-  expect(stream.getPosition().index).toBe(4);
-});
-
-test("ExponentReader rejects exponent missing digits after sign", () => {
-  const stream = new CharStream("1e+");
-  const pos = stream.getPosition();
-  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(tok).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
 });

--- a/tests/readers/ImportAssertionReader.test.js
+++ b/tests/readers/ImportAssertionReader.test.js
@@ -1,23 +1,24 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
 import { ImportAssertionReader } from "../../src/lexer/ImportAssertionReader.js";
-import { runReader } from "../utils/readerTestUtils.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
 test("ImportAssertionReader reads assert clause", () => {
-  const { token } = runReader(ImportAssertionReader, "assert { type: 'json' }");
-  expect(token.type).toBe("IMPORT_ASSERTION");
-  expect(token.value).toBe("assert { type: 'json' }");
+  expectToken(
+    ImportAssertionReader,
+    "assert { type: 'json' }",
+    "IMPORT_ASSERTION",
+    "assert { type: 'json' }"
+  );
 });
 
 test("ImportAssertionReader reads with colon syntax", () => {
-  const { token } = runReader(ImportAssertionReader, "assert: { type: 'json' }");
-  expect(token.type).toBe("IMPORT_ASSERTION");
-  expect(token.value).toBe("assert: { type: 'json' }");
+  expectToken(
+    ImportAssertionReader,
+    "assert: { type: 'json' }",
+    "IMPORT_ASSERTION",
+    "assert: { type: 'json' }"
+  );
 });
 
 test("ImportAssertionReader returns null for non-matching text", () => {
-  const stream = new CharStream("assert true");
-  const pos = stream.getPosition();
-  const { token } = runReader(ImportAssertionReader, undefined, undefined, stream);
-  expect(token).toBeNull();
-  expect(stream.getPosition()).toEqual(pos);
+  expectNull(ImportAssertionReader, "assert true");
 });

--- a/tests/readers/ImportMetaReader.test.js
+++ b/tests/readers/ImportMetaReader.test.js
@@ -1,18 +1,10 @@
-import { CharStream } from "../../src/lexer/CharStream.js";
-import { Token } from "../../src/lexer/Token.js";
 import { ImportMetaReader } from "../../src/lexer/ImportMetaReader.js";
+import { expectToken, expectNull } from "../utils/readerTestUtils.js";
 
- test("ImportMetaReader reads import.meta", () => {
-   const stream = new CharStream("import.meta");
-   const tok = ImportMetaReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-   expect(tok.type).toBe("IMPORT_META");
-   expect(tok.value).toBe("import.meta");
- });
+test("ImportMetaReader reads import.meta", () => {
+  expectToken(ImportMetaReader, "import.meta", "IMPORT_META", "import.meta");
+});
 
- test("ImportMetaReader returns null when sequence mismatched", () => {
-   const stream = new CharStream("import.met");
-   const pos = stream.getPosition();
-   const tok = ImportMetaReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-   expect(tok).toBeNull();
-   expect(stream.getPosition()).toEqual(pos);
- });
+test("ImportMetaReader returns null when sequence mismatched", () => {
+  expectNull(ImportMetaReader, "import.met");
+});


### PR DESCRIPTION
## Summary
- flatten several reader tests using shared test utilities
- replace manual stream setups with `expectToken`/`expectNull`

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_68575d80e87c8331812a46734cdd1060