### PR TITLE
[agent] feat(utils): extract token analysis helpers

### DIFF
--- a/src/utils/tokenAnalysis.js
+++ b/src/utils/tokenAnalysis.js
@@ -1,0 +1,46 @@
+export const opLike = /^(\|>|==?=?|!==?|<=?|>=?|[-+*/%]=?)$/;
+
+export function analyseTokens(tokens) {
+  const stats = new Map();
+  const problems = [];
+  const stack = [];
+  const pushProb = (tok, msg) => {
+    problems.push({ line: tok.start.line, col: tok.start.column + 1, val: tok.value, msg });
+  };
+
+  for (const t of tokens) {
+    stats.set(t.type, (stats.get(t.type) || 0) + 1);
+    if (t.type === 'ERROR_TOKEN' || t.type.startsWith('INVALID')) pushProb(t, 'lexer error token');
+    if (t.type === 'IDENTIFIER' && opLike.test(t.value)) pushProb(t, 'identifier looks like operator');
+
+    if (t.type === 'PUNCTUATION') {
+      if ('{(['.includes(t.value)) stack.push(t.value);
+      if ('}])'.includes(t.value)) {
+        const o = stack.pop();
+        if (!o || '({['.indexOf(o) !== ')}]'.indexOf(t.value)) pushProb(t, 'unbalanced bracket');
+      }
+    }
+  }
+  if (stack.length) pushProb(tokens[tokens.length - 1], 'unclosed bracket');
+  return { stats, problems };
+}
+
+export function unicodeBad(tokens) {
+  return tokens.filter(t => t.type === 'IDENTIFIER' && /[\uD800-\uDFFF]/.test(t.value));
+}
+
+export function maxDepth(tokens) {
+  let d = 0, max = 0;
+  for (const t of tokens) {
+    if ('([{'.includes(t.value)) d++;
+    if (')]}'.includes(t.value)) d--;
+    max = Math.max(max, d);
+  }
+  return max;
+}
+
+export function lineMap(tokens) {
+  const m = new Map();
+  tokens.forEach(t => m.set(t.start.line, [...(m.get(t.start.line) || []), t]));
+  return m;
+}

--- a/tests/tokenAnalysis.test.js
+++ b/tests/tokenAnalysis.test.js
@@ -1,0 +1,26 @@
+import { tokenize } from '../src/index.js';
+import { analyseTokens, unicodeBad, maxDepth, lineMap } from '../src/utils/tokenAnalysis.js';
+
+test('analyseTokens computes statistics and finds no problems for valid code', () => {
+  const tokens = tokenize('let x=1;');
+  const { stats, problems } = analyseTokens(tokens);
+  expect(stats.get('KEYWORD')).toBe(1);
+  expect(problems.length).toBe(0);
+});
+
+test('unicodeBad detects invalid identifier characters', () => {
+  const invalid = [{ type: 'IDENTIFIER', value: '\uD800', start: { line: 1, column: 0 }, end: { line: 1, column: 1 } }];
+  expect(unicodeBad(invalid).length).toBe(1);
+});
+
+test('maxDepth calculates bracket depth', () => {
+  const tokens = tokenize('(1+(2))');
+  expect(maxDepth(tokens)).toBe(2);
+});
+
+test('lineMap groups tokens by line', () => {
+  const tokens = tokenize('let x=1;\nlet y=2;');
+  const map = lineMap(tokens);
+  expect(map.get(1).length).toBeGreaterThan(0);
+  expect(map.get(2).length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- refactor diagnostics to delegate analysis utilities
- add tokenAnalysis module for shared helper functions
- test tokenAnalysis functionality

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685778bd34a48331b5b61c6f968f4c11