### PR TITLE
[agent] docs: note npm removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ The agent container sets `HUSKY=0` so Git hooks never block.
 | `yarn diag` | Diagnostics CLI. |
 | `yarn workflow` | Umbrella: lint → test → coverage → bench. |
 
+*NPM scripts are deprecated and will be removed; use the Yarn commands above.*
+
 ## 🤖  Codex playbook
 > *Read by the agent before each task.*
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![coverage ≥ 90%](https://img.shields.io/badge/coverage-90%2B-brightgreen)](./coverage)
 [![npm v](https://img.shields.io/npm/v/lexinator?logo=npm)](https://www.npmjs.com/package/lexinator)
 
+> **Note**: The repository is switching to Yarn as the sole package manager. Remaining npm files will be removed soon.
+
 *Modular, incremental&hairsp;/&hairsp;buffered JavaScript lexer with experiment-grade plug-ability.*
 
 ---
@@ -22,7 +24,7 @@
 
 Run `yarn install` to set up dependencies (Yarn v4).
 
-npm i lexinator
+yarn add lexinator
 
 import { tokenize } from 'lexinator';
 
@@ -74,7 +76,7 @@ Authoring a plugin? See AGENTS.md → “Plugin” for the contract.
 ╠══╗ 📂 .husky
 ║  ╠══ 📄 pre-commit
 ║  ╚═══ 📂 ..
-╠══ 📄 .npmrc
+╠══ 📄 .npmrc  *(to be removed)*
 ╠══ 📄 .releaserc
 ╠══╗ 📂 .yarn
 ║  ╚══ 📄 install-state.gz
@@ -89,7 +91,7 @@ Authoring a plugin? See AGENTS.md → “Plugin” for the contract.
 ║  ╚══ 📄 PLUGIN_API.md
 ╠══ 📄 fileStructure.txt
 ╠══ 📄 jest.config.cjs
-╠══ 📄 package-lock.json
+╠══ 📄 package-lock.json  *(to be removed)*
 ╠══ 📄 package.json
 ╠══ 📄 README.md
 ╠══╗ 📂 src


### PR DESCRIPTION
## Summary
- add note about Yarn replacing npm in README
- mark `.npmrc` and `package-lock.json` as pending removal
- mention deprecated npm scripts in AGENTS guide

## Testing
- `yarn workflow`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6857bd7de91c8331aaf2fa11dad80bde