### PR TITLE
[agent] increase test coverage

### DIFF
--- a/tests/readers/DoExpressionReader.test.js
+++ b/tests/readers/DoExpressionReader.test.js
@@ -52,3 +52,25 @@ test("DoExpressionReader tracks nested blocks", () => {
   expect(endOuter.type).toBe("DO_BLOCK_END");
   expect(engine.currentMode()).toBe("default");
 });
+
+test("DoExpressionReader returns null without brace", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("do value");
+  const pos = stream.getPosition();
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("DoExpressionReader handles inner braces depth", () => {
+  const engine = { ...dummyEngine, stateStack: ['do_block'], doBlockDepth: 0 };
+  const stream = new CharStream("{ }");
+  let tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(engine.doBlockDepth).toBe(1);
+  stream.advance(); // skip '{'
+  stream.advance(); // move to '}'
+  tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(engine.doBlockDepth).toBe(0);
+});

--- a/tests/readers/FunctionSentReader.test.js
+++ b/tests/readers/FunctionSentReader.test.js
@@ -16,3 +16,7 @@ test("FunctionSentReader returns null inside identifier", () => {
   stream.advance();
   expectNull(FunctionSentReader, stream);
 });
+
+test("FunctionSentReader requires word boundary", () => {
+  expectNull(FunctionSentReader, "function.sentx");
+});

--- a/tests/readers/ImportCallReader.test.js
+++ b/tests/readers/ImportCallReader.test.js
@@ -1,0 +1,32 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ImportCallReader } from "../../src/lexer/ImportCallReader.js";
+
+function run(src) {
+  const stream = new CharStream(src);
+  const tok = ImportCallReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  return { tok, stream };
+}
+
+test("ImportCallReader reads import call", () => {
+  const { tok, stream } = run("import(foo)");
+  expect(tok.type).toBe("IMPORT_CALL");
+  expect(tok.value).toBe("import");
+  expect(stream.current()).toBe("(");
+});
+
+test("ImportCallReader requires parentheses", () => {
+  const stream = new CharStream("import foo");
+  const pos = stream.getPosition();
+  const tok = ImportCallReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("ImportCallReader returns null for non-matching text", () => {
+  const stream = new CharStream("impost(");
+  const pos = stream.getPosition();
+  const tok = ImportCallReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/ModuleBlockReader.test.js
+++ b/tests/readers/ModuleBlockReader.test.js
@@ -54,3 +54,25 @@ test("ModuleBlockReader returns null when not matched", () => {
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("ModuleBlockReader handles inner braces depth", () => {
+  const engine = { ...dummyEngine, stateStack: ['module_block'], moduleBlockDepth: 0 };
+  const stream = new CharStream("{ }");
+  let tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(engine.moduleBlockDepth).toBe(1);
+  stream.advance(); // skip '{'
+  stream.advance(); // move to '}'
+  tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(engine.moduleBlockDepth).toBe(0);
+});
+
+test("ModuleBlockReader requires opening brace", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("module x");
+  const pos = stream.getPosition();
+  const tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/PatternMatchReader.test.js
+++ b/tests/readers/PatternMatchReader.test.js
@@ -26,3 +26,19 @@ test("PatternMatchReader returns null inside identifier", () => {
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("PatternMatchReader requires word boundary after match", () => {
+  const stream = new CharStream("matcha");
+  const pos = stream.getPosition();
+  const tok = PatternMatchReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("PatternMatchReader requires word boundary after case", () => {
+  const stream = new CharStream("casex");
+  const pos = stream.getPosition();
+  const tok = PatternMatchReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- add tests for ImportCallReader
- broaden DoExpressionReader tests
- cover more ModuleBlockReader branches
- expand PatternMatchReader scenarios
- add FunctionSentReader edge case

## Testing
- `yarn run --silent lint`
- `yarn run --silent test --coverage`
- `npm run lint`
- `npm test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_6857c8c8fb4883319a42f4ed8da97fab