### PR TITLE
[agent] test: cover additional branches in tokenAnalysis

### DIFF
--- a/tests/tokenAnalysis.test.js
+++ b/tests/tokenAnalysis.test.js
@@ -24,3 +24,30 @@ test('lineMap groups tokens by line', () => {
   expect(map.get(1).length).toBeGreaterThan(0);
   expect(map.get(2).length).toBeGreaterThan(0);
 });
+
+test('analyseTokens reports operator-like identifiers and error tokens', () => {
+  const custom = [
+    { type: 'IDENTIFIER', value: '==', start: { line: 1, column: 0 } },
+    { type: 'ERROR_TOKEN', value: '$', start: { line: 1, column: 2 } }
+  ];
+  const { problems } = analyseTokens(custom);
+  expect(problems).toEqual([
+    { line: 1, col: 1, val: '==', msg: 'identifier looks like operator' },
+    { line: 1, col: 3, val: '$', msg: 'lexer error token' }
+  ]);
+});
+
+test('analyseTokens reports bracket issues', () => {
+  const mismatch = [
+    { type: 'PUNCTUATION', value: '{', start: { line: 1, column: 0 } },
+    { type: 'PUNCTUATION', value: ']', start: { line: 1, column: 1 } }
+  ];
+  const { problems: prob1 } = analyseTokens(mismatch);
+  expect(prob1[0].msg).toBe('unbalanced bracket');
+
+  const unclosed = [
+    { type: 'PUNCTUATION', value: '{', start: { line: 2, column: 0 } }
+  ];
+  const { problems: prob2 } = analyseTokens(unclosed);
+  expect(prob2[0].msg).toBe('unclosed bracket');
+});


### PR DESCRIPTION
## Summary
- improve unit tests for `analyseTokens`

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6857d3d215e88331b0bb05b1a201d58a