### PR TITLE
[agent] feat: allow custom token factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ const tsTokens = tokenize('let a: number = 1');
 clearPlugins();
 Authoring a plugin? See AGENTS.md → “Plugin” for the contract.
 
+### Custom token factory
+
+Instrument token creation by supplying `createToken` when constructing a lexer:
+
+```javascript
+import { createTokenStream } from 'lexinator';
+import { Token } from 'lexinator/src/lexer/Token.js';
+
+const seen = [];
+createTokenStream('let x = 1;', {
+  createToken(type, val, start, end, url) {
+    const tok = new Token(type, val, start, end, url);
+    seen.push(tok);
+    return tok;
+  }
+});
+```
+
+#Project layout
+
 #Project layout
 📂 Lexinator
 ╠══ 📄 .eslintrc.cjs

--- a/src/integration/BaseIncrementalLexer.js
+++ b/src/integration/BaseIncrementalLexer.js
@@ -9,11 +9,11 @@ import { saveState, restoreState } from './stateUtils.js';
  * implement the `feed()` method to consume input and emit tokens.
  */
 export class BaseIncrementalLexer {
-  constructor({ onToken, errorRecovery = false, sourceURL = null } = {}) {
+  constructor({ onToken, errorRecovery = false, sourceURL = null, createToken } = {}) {
     this.onToken = onToken || (() => {});
     this.tokens = [];
     this.stream = new CharStream('', { sourceURL });
-    this.engine = new LexerEngine(this.stream, { errorRecovery });
+    this.engine = new LexerEngine(this.stream, { errorRecovery, createToken });
     // dependencies for state helpers
     this._deps = { CharStream, LexerEngine, Token };
   }

--- a/src/integration/TokenStream.js
+++ b/src/integration/TokenStream.js
@@ -18,12 +18,13 @@ export class TokenStream extends Readable {
       CharStream: CharStreamClass = CharStream,
       LexerEngine: LexerEngineClass = LexerEngine,
       iteratorFn = tokenIterator,
-      errorRecovery = false
+      errorRecovery = false,
+      createToken
     } = {}
   ) {
     super({ objectMode: true });
     this.stream = new CharStreamClass(code);
-    this.engine = new LexerEngineClass(this.stream, { errorRecovery });
+    this.engine = new LexerEngineClass(this.stream, { errorRecovery, createToken });
     this.iter = iteratorFn(this.engine);
   }
 

--- a/tests/customFactory.test.js
+++ b/tests/customFactory.test.js
@@ -1,0 +1,18 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { Token } from '../src/lexer/Token.js';
+
+ test('custom createToken option tags tokens', () => {
+   const captured = [];
+   const createToken = (type, val, s, e, src) => {
+     const tok = new Token(type, val, s, e, src);
+     tok.tagged = true;
+     captured.push(tok);
+     return tok;
+   };
+   const engine = new LexerEngine(new CharStream('1'), { createToken });
+   const tok = engine.nextToken();
+   expect(tok.tagged).toBe(true);
+   expect(captured[0]).toBe(tok);
+ });
+


### PR DESCRIPTION
## Summary
- add optional `createToken` hook for `LexerEngine`
- plumb token factory option through stream and incremental lexer
- document token factory usage in README
- test custom token factory feature

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6857fa265494833182680c0836e2104f