### PR TITLE
[agent] chore: refine lint and diagnostics

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,7 @@ module.exports = {
     "indent": ["warn", 2],
     "no-trailing-spaces": "warn",
     "eol-last": ["warn", "always"],
+    "no-multi-spaces": "warn",
+    "no-multiple-empty-lines": ["warn", { "max": 1 }],
   },
 };

--- a/src/utils/diagnostics.js
+++ b/src/utils/diagnostics.js
@@ -16,8 +16,8 @@ import { LexerEngine } from '../lexer/LexerEngine.js';
 import { analyseTokens, unicodeBad, maxDepth, lineMap } from './tokenAnalysis.js';
 
 /* ── ANSI helper ─────────────────────────────────────────────────── */
-const clr = (c, s) =>
-  `\x1b[${{ red:31, green:32, yellow:33, cyan:36, magenta:35 }[c]}m${s}\x1b[0m`;
+const CLR_CODES = { red: 31, green: 32, yellow: 33, cyan: 36, magenta: 35 };
+const clr = (c, s) => `\x1b[${CLR_CODES[c]}m${s}\x1b[0m`;
 
 /* ── HELP flag ───────────────────────────────────────────────────── */
 if (process.argv.includes('--help')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "newLine": "lf"
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary
- refine `diagnostics` color helper
- tighten ESLint rules for spacing
- enable stricter TypeScript checks

## Testing
- `yarn lint`
- `yarn test --coverage`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685801f2dd088331952c5c93983f43fd