### PR TITLE
[agent] chore: add TypeScript radix readers

### DIFF
--- a/src/lexer/number/BinaryReader.ts
+++ b/src/lexer/number/BinaryReader.ts
@@ -1,0 +1,11 @@
+import { createRadixReader } from './RadixReader.js';
+
+/**
+ * §4.4 BinaryReader
+ * Parses binary integer literals like 0b1010 or 0B0101.
+ */
+export const BinaryReader = createRadixReader(
+  ['b', 'B'],
+  (ch: string | null): boolean => ch === '0' || ch === '1'
+);
+

--- a/src/lexer/number/HexReader.ts
+++ b/src/lexer/number/HexReader.ts
@@ -1,0 +1,10 @@
+import { createRadixReader, isHexDigit } from './RadixReader.js';
+
+/**
+ * §4.4 HexReader
+ * Parses hexadecimal integer literals like 0xFF.
+ */
+export const HexReader = createRadixReader(
+  ['x', 'X'],
+  isHexDigit
+);

--- a/src/lexer/number/OctalReader.ts
+++ b/src/lexer/number/OctalReader.ts
@@ -1,0 +1,10 @@
+import { createRadixReader } from './RadixReader.js';
+
+/**
+ * §4.4 OctalReader
+ * Parses octal integer literals like 0o777 or 0O123.
+ */
+export const OctalReader = createRadixReader(
+  ['o', 'O'],
+  (ch: string | null): boolean => ch !== null && ch >= '0' && ch <= '7'
+);

--- a/src/lexer/number/RadixReader.ts
+++ b/src/lexer/number/RadixReader.ts
@@ -1,0 +1,46 @@
+// ─── src/lexer/RadixReader.js ────────────────────────────────────────────────
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+
+export const isHexDigit = (ch: string | null): boolean =>
+  ch !== null && (
+    (ch >= '0' && ch <= '9') ||
+    (ch >= 'a' && ch <= 'f') ||
+    (ch >= 'A' && ch <= 'F')
+  );
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export const createRadixReader = (
+  prefixes: string[],
+  isOk: (ch: string | null) => boolean
+) => (
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null => {
+  const start = stream.getPosition();
+
+  /* 0x / 0b / 0o prefix -----------------------------------------------------*/
+  if (stream.current() !== '0') return null;
+  const p = stream.peek();
+  if (!prefixes.includes(p)) return null;
+  const nxt = stream.peek(2);
+  if (nxt === null || !isOk(nxt)) return null;
+
+  const buf = ['0', p];
+  stream.advance();               // 0
+  stream.advance();               // x | b | o
+
+  /* now copy digits while they are valid _and_ we’re not at EOF */
+  while (stream.current() !== null && isOk(stream.current())) {
+    buf.push(stream.current());
+    stream.advance();
+  }
+
+  return factory('NUMBER', buf.join(''), start, stream.getPosition());
+};


### PR DESCRIPTION
## Summary
- add new TypeScript versions of `RadixReader`, `BinaryReader`, `HexReader`, and `OctalReader`
- maintain JS imports for runtime compatibility

## Testing
- `yarn lint`
- `yarn test`
- `node src/utils/diagnostics.js "let x = 1"`

------
https://chatgpt.com/codex/tasks/task_e_6859ba9081108331bbcd2cf67148a7bf