### PR TITLE
[agent] Convert JavaScript grammar to TypeScript

### DIFF
--- a/src/grammar/JavaScriptGrammar.ts
+++ b/src/grammar/JavaScriptGrammar.ts
@@ -1,0 +1,35 @@
+// JavaScript grammar definitions
+const keywords = [
+  "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
+  "do", "else", "export", "extends", "finally", "for", "function", "if", "import",
+  "in", "instanceof", "let",
+  "new", "return", "super", "switch", "this", "throw", "try", "typeof", "var", "void",
+  "while", "with", "yield"
+];
+
+const operators = [
+  "?.", "??", "??=", "|>",
+  "+", "-", "*", "/", "%", "++", "--", "=", "+=", "-=", "*=", "**", "/=", "%=", "**=", "==", "===", "!=", "!==",
+  "&&=", "||=",
+  ">", "<", ">=", "<=", "&&", "||", "!", "?", "...", "=>"
+];
+
+const punctuation = ["{", "}", "(", ")", "[", "]", ".", ";", ","];
+
+export interface JSGrammar {
+  keywords: string[];
+  keywordSet: Set<string>;
+  operators: string[];
+  sortedOperators: string[];
+  punctuation: string[];
+  punctuationSet: Set<string>;
+}
+
+export const JavaScriptGrammar: JSGrammar = {
+  keywords,
+  keywordSet: new Set(keywords),
+  operators,
+  sortedOperators: operators.slice().sort((a, b) => b.length - a.length),
+  punctuation,
+  punctuationSet: new Set(punctuation)
+};


### PR DESCRIPTION
## Summary
- convert `JavaScriptGrammar.js` to TypeScript

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859c59df6488331a852e2f9333ee8b7