### PR TITLE
[agent] feat: add TS definitions for numeric readers

### DIFF
--- a/src/lexer/number/BigIntReader.ts
+++ b/src/lexer/number/BigIntReader.ts
@@ -1,0 +1,51 @@
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+import { readDigitsWithUnderscores, isDigit } from '../utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function BigIntReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+  if (!isDigit(ch)) return null;
+
+  // verify there is a trailing 'n' so this is really a bigint
+  let idx = stream.index;
+  while (idx < stream.input.length && /[0-9_]/.test(stream.input[idx])) {
+    idx++;
+  }
+  if (stream.input[idx] !== 'n') return null;
+
+  const result = readDigitsWithUnderscores(stream, startPos);
+  if (!result) return null;
+  let { value, underscoreSeen, lastUnderscore } = result;
+  ch = stream.current();
+
+  if (lastUnderscore) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  if (underscoreSeen && value.startsWith('_')) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  if (ch !== 'n') {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  value += 'n';
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('BIGINT', value, startPos, endPos);
+}

--- a/src/lexer/number/DecimalLiteralReader.ts
+++ b/src/lexer/number/DecimalLiteralReader.ts
@@ -1,0 +1,54 @@
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+import { readNumberLiteral, isDigit } from '../utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function DecimalLiteralReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+
+  // prefix form 0d123.45
+  if (ch === '0' && (stream.peek() === 'd' || stream.peek() === 'D')) {
+    // ensure digits after prefix
+    const firstDigit = stream.peek(2);
+    if (!isDigit(firstDigit)) return null;
+
+    let value = '0' + stream.peek();
+    stream.advance(); // 0
+    stream.advance(); // d or D
+    const result = readNumberLiteral(stream, startPos, true);
+    if (!result) return null;
+    value += result.value;
+    const endPos = stream.getPosition();
+    return factory('DECIMAL', value, startPos, endPos);
+  }
+
+  // suffix form 123.45m or 123m
+  if (isDigit(ch)) {
+    const result = readNumberLiteral(stream, startPos, true);
+    if (result) {
+      let { value, ch: next } = result;
+      if (next === 'm' || next === 'M') {
+        value += next;
+        stream.advance();
+        const endPos = stream.getPosition();
+        return factory('DECIMAL', value, startPos, endPos);
+      }
+    } else {
+      return null;
+    }
+  }
+
+  // not a decimal literal
+  stream.setPosition(startPos);
+  return null;
+}

--- a/src/lexer/number/ExponentReader.ts
+++ b/src/lexer/number/ExponentReader.ts
@@ -1,0 +1,46 @@
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+import { readNumberLiteral, readDigits, isDigit } from '../utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ExponentReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (!isDigit(stream.current())) return null;
+
+  const numberResult = readNumberLiteral(stream, startPos);
+  if (!numberResult) return null;
+  let { value, ch } = numberResult;
+
+  if (ch !== 'e' && ch !== 'E') {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+
+  if (ch === '+' || ch === '-') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const exponent = readDigits(stream);
+  if (exponent.length === 0) {
+    stream.setPosition(startPos);
+    return null;
+  }
+  value += exponent;
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}

--- a/src/lexer/number/NumberReader.ts
+++ b/src/lexer/number/NumberReader.ts
@@ -1,0 +1,25 @@
+// §4.2 NumberReader
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+import { readNumberLiteral, isDigit } from '../utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function NumberReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (!isDigit(stream.current())) return null;
+
+  const result = readNumberLiteral(stream, startPos);
+  if (!result) return null;
+  const { value } = result;
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}

--- a/src/lexer/number/NumericSeparatorReader.ts
+++ b/src/lexer/number/NumericSeparatorReader.ts
@@ -1,0 +1,31 @@
+import type { CharStream } from '../CharStream.js';
+import type { Token } from '../Token.js';
+import { readDigitsWithUnderscores, isDigit } from '../utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function NumericSeparatorReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+  if (!isDigit(ch)) return null;
+
+  const result = readDigitsWithUnderscores(stream, startPos);
+  if (!result) return null;
+  const { value, underscoreSeen, lastUnderscore } = result;
+
+  if (!underscoreSeen || lastUnderscore) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}


### PR DESCRIPTION
## Summary
- add TypeScript versions for numeric lexer readers

## Testing
- `yarn lint`
- `yarn test`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859c59df6488331a852e2f9333ee8b7