### PR TITLE
[agent] chore(ts): migrate additional modules to TypeScript

### DIFF
--- a/src/integration/BaseIncrementalLexer.ts
+++ b/src/integration/BaseIncrementalLexer.ts
@@ -1,0 +1,74 @@
+import type { CharStream } from '../lexer/CharStream.js';
+import type { LexerEngine } from '../lexer/LexerEngine.js';
+import type { Token } from '../lexer/Token.js';
+import { CharStream } from '../lexer/CharStream.js';
+import { LexerEngine } from '../lexer/LexerEngine.js';
+import { Token as TokenCtor } from '../lexer/Token.js';
+import { saveState, restoreState } from './stateUtils.js';
+
+/**
+ * BaseIncrementalLexer provides shared setup and state utilities for
+ * incremental lexer implementations. Subclasses are expected to
+ * implement the `feed()` method to consume input and emit tokens.
+ */
+export interface BaseLexerOptions {
+  onToken?: (t: Token) => void;
+  errorRecovery?: boolean;
+  sourceURL?: string | null;
+  createToken?: (type: string, val: any, s: any, e: any, src?: string | null) => Token;
+}
+
+export class BaseIncrementalLexer {
+  onToken: (t: Token) => void;
+  tokens: Token[];
+  stream: CharStream;
+  engine: LexerEngine;
+  _deps: { CharStream: typeof CharStream; LexerEngine: typeof LexerEngine; Token: typeof TokenCtor };
+
+  constructor({ onToken, errorRecovery = false, sourceURL = null, createToken }: BaseLexerOptions = {}) {
+    this.onToken = onToken || (() => {});
+    this.tokens = [];
+    this.stream = new CharStream('', { sourceURL });
+    this.engine = new LexerEngine(this.stream, { errorRecovery, createToken });
+    // dependencies for state helpers
+    this._deps = { CharStream, LexerEngine, Token: TokenCtor };
+  }
+
+  /**
+   * Push a token to the internal list and notify the callback.
+   * @param {Token} token Token to emit
+   */
+  emit(token: Token): void {
+    this.tokens.push(token);
+    this.onToken(token);
+  }
+
+  /**
+   * Return all tokens produced so far.
+   */
+  getTokens(): Token[] {
+    return this.tokens.slice();
+  }
+
+  /**
+   * Serialize the lexer's internal state for persistence.
+   * @param {boolean} includeTrivia When true, also persists trivia tokens.
+   */
+  saveState(includeTrivia = false): any {
+    return saveState(this, includeTrivia);
+  }
+
+  /**
+   * Restore a previously saved lexer state.
+   * @param {object} state
+   * @param {boolean} includeTrivia When true, also restores trivia tokens.
+   */
+  restoreState(state: any, includeTrivia = false): void {
+    restoreState(this, state, includeTrivia);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  feed(): void {
+    throw new Error('feed() must be implemented by subclass');
+  }
+}

--- a/src/integration/BufferedIncrementalLexer.ts
+++ b/src/integration/BufferedIncrementalLexer.ts
@@ -1,0 +1,74 @@
+// src/integration/BufferedIncrementalLexer.js
+
+import { BaseIncrementalLexer, BaseLexerOptions } from './BaseIncrementalLexer.js';
+import { LexerError } from '../lexer/LexerError.js';
+import type { Token } from '../lexer/Token.js';
+
+function isIncompleteBlockComment(token, stream) {
+  return (
+    token.type === 'COMMENT' &&
+    token.value.startsWith('/*') &&
+    !token.value.endsWith('*/') &&
+    stream.eof()
+  );
+}
+
+export class BufferedIncrementalLexer extends BaseIncrementalLexer {
+  trivia: Token[];
+
+  constructor(options: BaseLexerOptions = {}) {
+    super(options);
+    this.trivia = [];
+  }
+
+  feed(chunk: string): void {
+    this.stream.append(chunk);
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const pos = this.stream.getPosition();
+      let token: Token | null = null;
+
+      try {
+        token = this.engine.nextToken();
+      } catch (err) {
+        if (err instanceof LexerError && err.end.index >= this.stream.input.length) {
+          // Incomplete token at end of input – rewind and wait for more data.
+          this.stream.setPosition(pos);
+          break;
+        }
+        throw err;
+      }
+
+      if (token === null) break;
+
+      // Handle incomplete multi-line comments specially.
+      if (isIncompleteBlockComment(token, this.stream)) {
+        this.stream.setPosition(pos);
+        break;
+      }
+
+      // Trivia handling with lazy allocation.
+      if (token.type === 'WHITESPACE') {
+        this.trivia.push(token);
+        continue;
+      }
+
+      if (this.trivia.length) token.attachLeading(this.trivia);
+      if (this.tokens.length && this.trivia.length) {
+        this.tokens[this.tokens.length - 1].attachTrailing(this.trivia);
+      }
+      this.trivia = [];
+
+      this.emit(token);
+    }
+  }
+
+  saveState(): any {
+    return super.saveState(true);
+  }
+
+  restoreState(state: any): void {
+    super.restoreState(state, true);
+  }
+}

--- a/src/integration/IncrementalLexer.ts
+++ b/src/integration/IncrementalLexer.ts
@@ -1,0 +1,23 @@
+import { BaseIncrementalLexer, BaseLexerOptions } from './BaseIncrementalLexer.js';
+import { tokenIterator } from './tokenUtils.js';
+
+/**
+ * IncrementalLexer allows feeding code chunks and emits tokens as they are produced.
+ */
+export class IncrementalLexer extends BaseIncrementalLexer {
+  constructor(options: BaseLexerOptions = {}) {
+    super(options);
+  }
+
+  /**
+   * Feed additional source text to the lexer.
+   * @param {string} chunk
+   */
+  feed(chunk: string): void {
+    this.stream.append(chunk);
+    for (const token of tokenIterator(this.engine)) {
+      this.emit(token);
+    }
+  }
+
+}

--- a/src/lexer/LexerEngine.ts
+++ b/src/lexer/LexerEngine.ts
@@ -1,0 +1,262 @@
+// ─── src/lexer/LexerEngine.js ───────────────────────────────────────────────
+import { RegexOrDivideReader }    from './RegexOrDivideReader.js';
+import { TemplateStringReader }   from './TemplateStringReader.js';
+import { JSXReader }              from './JSXReader.js';
+import { CommentReader }          from './CommentReader.js';
+import { HTMLCommentReader }      from './HTMLCommentReader.js';
+import { SourceMappingURLReader } from './SourceMappingURLReader.js';
+
+import type { CharStream }        from './CharStream.js';
+import type { Position, Token }   from './Token.js';
+
+import { baseReaders }            from './defaultReaders.js';
+import { Token }                  from './Token.js';
+import { LexerError }             from './LexerError.js';
+import { JavaScriptGrammar }      from '../grammar/JavaScriptGrammar.js';
+import { runReader }              from './TokenReader.js';
+import { getPlugins }             from '../pluginManager.js';
+
+/* ── fast-lookup tables ──────────────────────────────────────────────────── */
+const SINGLE_CHAR_OPS = new Set(
+  JavaScriptGrammar.operators.filter(op => op.length === 1)
+);
+const PIPE_OP        = '|>';
+const PUNCTUATION_SET = JavaScriptGrammar.punctuationSet;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  LEXER ENGINE
+ * ═════════════════════════════════════════════════════════════════════════ */
+export interface LexerEngineOptions {
+  errorRecovery?: boolean;
+  validateUnicodeProperties?: boolean;
+  stateInput?: string;
+  createToken?: (
+    type: string,
+    val: any,
+    start: Position,
+    end: Position,
+    src?: string | null
+  ) => Token;
+}
+
+export class LexerEngine {
+  stream: CharStream;
+  errorRecovery: boolean;
+  validateUnicodeProperties: boolean;
+  stateInput: string;
+  createToken: (
+    type: string,
+    val: any,
+    start: Position,
+    end: Position,
+    src?: string | null
+  ) => Token;
+  stateStack: string[];
+  buffer: Token[];
+  disableJsx: boolean;
+  lastToken: Token | null;
+  triviaReaders: any[];
+  modes: Record<string, any[]>;
+
+  constructor(
+    stream: CharStream,
+    {
+      errorRecovery = false,
+      validateUnicodeProperties = false,
+      stateInput = 'full',
+      createToken
+    }: LexerEngineOptions = {}
+  ) {
+    this.stream   = stream;
+    this.errorRecovery             = !!errorRecovery;
+    this.validateUnicodeProperties = !!validateUnicodeProperties;
+    this.stateInput                = stateInput;
+    this.createToken               =
+      createToken ||
+      ((type, val, s, e, src) => new Token(type, val, s, e, src));
+
+    this.stateStack = ['default'];
+    this.buffer     = [];
+    this.disableJsx = false;
+    this.lastToken  = null;
+
+    this.triviaReaders = [HTMLCommentReader, SourceMappingURLReader, CommentReader];
+
+    const shared = [...baseReaders];
+    /** @type {Record<string, Function[]>} */
+    this.modes = {
+      default:         [...shared],
+      do_block:        [...shared],
+      module_block:    [...shared],
+      template_string: [TemplateStringReader],
+      regex:           [RegexOrDivideReader],
+      jsx:             [JSXReader]
+    };
+
+    for(const pl of getPlugins()){
+      if(pl.modes){
+        for(const [m, rd] of Object.entries(pl.modes)) this.addReaders(m, ...rd);
+      }
+      if(typeof pl.init==='function') pl.init(this);
+    }
+  }
+
+  /* ───────── mode helpers ───────── */
+  currentMode(){ return this.stateStack[this.stateStack.length-1]; }
+  pushMode(m){ this.stateStack.push(m); }
+  popMode(){ if(this.stateStack.length>1) this.stateStack.pop(); }
+
+  addReaders(mode, ...readers){
+    if(!this.modes[mode]) this.modes[mode]=[];
+    const list=this.modes[mode];
+    for(let i=readers.length-1;i>=0;i--){
+      const r=readers[i];
+      const idx=list.indexOf(r);
+      if(idx!==-1) list.splice(idx,1);
+      list.unshift(r);
+    }
+  }
+
+  /* ───────── trivia ───────── */
+  _readTrivia(factory: (...args: any[]) => Token): Token | null {
+    for(const R of this.triviaReaders){
+      const tok=runReader(R,this.stream,factory,this);
+      if(tok) return tok;
+    }
+    return null;
+  }
+
+  /* ───────── utility: normalise operator tokens ───────── */
+  _normaliseOperator(tok: Token): Token {
+    if(tok.type!=='IDENTIFIER') return tok;
+
+    // pure operator symbol that was mis-typed
+    if(JavaScriptGrammar.operators.includes(tok.value)){
+      tok.type = tok.value===PIPE_OP ? 'PIPELINE_OPERATOR' : 'OPERATOR';
+      return tok;
+    }
+
+    // glued form like "=1"  or "|>b"
+    for(const op of JavaScriptGrammar.sortedOperators){
+      if(tok.value.startsWith(op)){
+        const opType = op===PIPE_OP ? 'PIPELINE_OPERATOR' : 'OPERATOR';
+
+        const { start } = tok;
+        const mid = { ...start, column:start.column+op.length,
+                                index:start.index+op.length };
+
+        const opTok   = this.createToken(
+          opType,
+          op,
+          start,
+          mid,
+          tok.sourceURL
+        );
+        const restVal = tok.value.slice(op.length);
+
+        /* decide the remainder’s token-type heuristically */
+        let restType = 'IDENTIFIER';
+        if(/^[0-9]/.test(restVal))     restType = 'NUMBER';
+        else if(restVal===';')         restType = 'PUNCTUATION';
+        else if(JavaScriptGrammar.operators.includes(restVal))
+          restType = restVal===PIPE_OP ? 'PIPELINE_OPERATOR' : 'OPERATOR';
+
+        const tailTok = this.createToken(
+          restType,
+          restVal,
+          mid,
+          tok.end,
+          tok.sourceURL
+        );
+        this.buffer.unshift(tailTok);          // emit after opTok on next pull
+        return opTok;
+      }
+    }
+    return tok;
+  }
+
+  /* ───────── inner loop ───────── */
+  _readFromStream(): Token | null {
+    const { stream } = this;
+    const factory = (type, val, s, e) =>
+      this.createToken(type, val, s, e, stream.sourceURL);
+
+    while(!stream.eof()){
+      const triv=this._readTrivia(factory);
+      if(triv){ this.lastToken=triv; return triv; }
+
+      /* JSX heuristic */
+      let mode=this.currentMode();
+      if(mode==='default' && !this.disableJsx &&
+         stream.current()==='<'
+         && /[A-Za-z/!?]/.test(stream.peek()))
+      {
+        this.pushMode('jsx'); mode='jsx';
+      }
+
+      /* mode-specific readers */
+      const readers=this.modes[mode]||this.modes.default;
+      for(const R of readers){
+        const res=runReader(R,stream,factory,this);
+        if(!res) continue;
+
+        if(res instanceof LexerError){
+          if(this.errorRecovery){
+            const { end }=res;
+            stream.setPosition(end);
+            if(end.index===res.start.index) stream.advance();
+            const v=stream.input.slice(res.start.index,stream.index);
+            const errTok=factory('ERROR_TOKEN',v,res.start,stream.getPosition());
+            this.lastToken=errTok; return errTok;
+          }
+          throw res;
+        }
+
+        /* keyword upgrade */
+        if(res.type==='IDENTIFIER' &&
+           JavaScriptGrammar.keywordSet.has(res.value))
+          res.type='KEYWORD';
+
+        this.lastToken=res;
+        return this._normaliseOperator(res);
+      }
+
+      /* single-char fallback */
+      const ch=stream.current();
+      if(ch!==null){
+        if(PUNCTUATION_SET.has(ch)){
+          const s=stream.getPosition(); stream.advance();
+          const tok=factory('PUNCTUATION',ch,s,stream.getPosition());
+          this.lastToken=tok; return tok;
+        }
+        if(SINGLE_CHAR_OPS.has(ch)){
+          const s=stream.getPosition(); stream.advance();
+          const tok=factory('OPERATOR',ch,s,stream.getPosition());
+          this.lastToken=tok; return tok;
+        }
+      }
+      stream.advance();                        // skip unknown rune
+    }
+    return null;                               // EOF
+  }
+
+  /* ───────── public API ───────── */
+  nextToken(): Token | null {
+    if(this.buffer.length){
+      this.lastToken=this.buffer.shift();
+      return this.lastToken;
+    }
+    const t=this._readFromStream();
+    this.lastToken=t;
+    return t;
+  }
+
+  peek(n = 1): Token | null {
+    while(this.buffer.length<n){
+      const t=this._readFromStream();
+      if(t===null) break;
+      this.buffer.push(t);
+    }
+    return this.buffer[n-1]||null;
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeScript versions of several incremental lexers
- port `LexerEngine` to TypeScript

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859c59df6488331a852e2f9333ee8b7