### PR TITLE
[agent] Convert more readers to TypeScript

### DIFF
--- a/src/lexer/ByteOrderMarkReader.ts
+++ b/src/lexer/ByteOrderMarkReader.ts
@@ -1,0 +1,21 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ByteOrderMarkReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '\uFEFF') return null;
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('BOM', '\uFEFF', startPos, endPos);
+}

--- a/src/lexer/IdentifierReader.ts
+++ b/src/lexer/IdentifierReader.ts
@@ -1,0 +1,22 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeIdentifierLike } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function IdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const start = stream.getPosition();
+  const value = consumeIdentifierLike(stream, { unicode: false });
+  if (value === null) return null;
+  return factory('IDENTIFIER', value, start, stream.getPosition());
+}
+
+export const IdentifierReaderClass = IdentifierReader;

--- a/src/lexer/ImportMetaReader.ts
+++ b/src/lexer/ImportMetaReader.ts
@@ -1,0 +1,20 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeKeyword } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ImportMetaReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const endPos = consumeKeyword(stream, 'import.meta', { checkPrev: false });
+  if (!endPos) return null;
+  return factory('IMPORT_META', 'import.meta', startPos, endPos);
+}

--- a/src/lexer/PipelineOperatorReader.ts
+++ b/src/lexer/PipelineOperatorReader.ts
@@ -1,0 +1,25 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function PipelineOperatorReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+
+  // “|>” must be contiguous – no whitespace is permitted inside the token.
+  if (stream.current() === '|' && stream.peek() === '>') {
+    stream.advance(); // '|'
+    stream.advance(); // '>'
+    const endPos = stream.getPosition();
+    return factory('PIPELINE_OPERATOR', '|>', startPos, endPos);
+  }
+  return null;
+}

--- a/src/lexer/PunctuationReader.ts
+++ b/src/lexer/PunctuationReader.ts
@@ -1,0 +1,24 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function PunctuationReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const ch = stream.current();
+  if (JavaScriptGrammar.punctuationSet.has(ch as string)) {
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('PUNCTUATION', ch as string, startPos, endPos);
+  }
+  return null;
+}

--- a/src/lexer/ShebangReader.ts
+++ b/src/lexer/ShebangReader.ts
@@ -1,0 +1,27 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ShebangReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '#' || stream.peek() !== '!') return null;
+
+  let value = '';
+  while (!stream.eof() && stream.current() !== '\n') {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('COMMENT', value, startPos, endPos);
+}

--- a/src/lexer/UnicodeEscapeIdentifierReader.ts
+++ b/src/lexer/UnicodeEscapeIdentifierReader.ts
@@ -1,0 +1,20 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeIdentifierLike } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UnicodeEscapeIdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const start = stream.getPosition();
+  const value = consumeIdentifierLike(stream, { unicode: true, allowEscape: true });
+  if (value === null) return null;
+  return factory('IDENTIFIER', value, start, stream.getPosition());
+}

--- a/src/lexer/UnicodeIdentifierReader.ts
+++ b/src/lexer/UnicodeIdentifierReader.ts
@@ -1,0 +1,23 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeIdentifierLike } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UnicodeIdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  // Fast bail-out: ASCII handled by IdentifierReader.
+  if (stream.current() === null || stream.current()!.charCodeAt(0) < 128) return null;
+
+  const start = stream.getPosition();
+  const value = consumeIdentifierLike(stream, { unicode: true });
+  if (value === null) return null;
+  return factory('IDENTIFIER', value, start, stream.getPosition());
+}

--- a/src/lexer/UnicodeWhitespaceReader.ts
+++ b/src/lexer/UnicodeWhitespaceReader.ts
@@ -1,0 +1,26 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+const WS_RE = /\p{White_Space}/u;
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UnicodeWhitespaceReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const start = stream.getPosition();
+  if (!WS_RE.test(stream.current() || '')) return null;
+
+  const buf: string[] = [];
+  while (!stream.eof() && WS_RE.test(stream.current() as string)) {
+    buf.push(stream.current() as string);
+    stream.advance();
+  }
+  return factory('WHITESPACE', buf.join(''), start, stream.getPosition());
+}

--- a/src/plugins/DecoratorPlugin.ts
+++ b/src/plugins/DecoratorPlugin.ts
@@ -1,0 +1,9 @@
+import type { Plugin } from '../pluginManager.js';
+import { TSDecoratorReader } from './common/TSDecoratorReader.js';
+
+export const DecoratorPlugin: Plugin = {
+  modes: { default: [TSDecoratorReader] },
+  init() {
+    // plugin hook for future engine tweaks
+  }
+};

--- a/src/plugins/importmeta/ImportMetaPlugin.ts
+++ b/src/plugins/importmeta/ImportMetaPlugin.ts
@@ -1,0 +1,12 @@
+import type { Plugin } from '../../pluginManager.js';
+import { ImportMetaReader } from '../../lexer/ImportMetaReader.js';
+import { ImportCallReader } from '../../lexer/ImportCallReader.js';
+
+export const ImportMetaPlugin: Plugin = {
+  // Declarative reader list (fallback)
+  modes: { default: [ImportMetaReader, ImportCallReader] },
+
+  init(engine: any) {
+    engine.addReaders('default', ImportMetaReader, ImportCallReader);
+  }
+};


### PR DESCRIPTION
## Summary
- add TypeScript versions of several simple readers and plugins

## Testing
- `yarn run --silent lint`
- `yarn run --silent test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_6859c76dfce483319bf3aabfe69f6c68