### PR TITLE
[agent] feat: add TypeScript readers

### DIFF
--- a/src/lexer/ByteOrderMarkReader.ts
+++ b/src/lexer/ByteOrderMarkReader.ts
@@ -1,0 +1,21 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ByteOrderMarkReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '\uFEFF') return null;
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('BOM', '\uFEFF', startPos, endPos);
+}

--- a/src/lexer/ShebangReader.ts
+++ b/src/lexer/ShebangReader.ts
@@ -1,0 +1,27 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ShebangReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '#' || stream.peek() !== '!') return null;
+
+  let value = '';
+  while (!stream.eof() && stream.current() !== '\n') {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('COMMENT', value, startPos, endPos);
+}

--- a/src/lexer/UnicodeEscapeIdentifierReader.ts
+++ b/src/lexer/UnicodeEscapeIdentifierReader.ts
@@ -1,0 +1,21 @@
+// src/lexer/UnicodeEscapeIdentifierReader.ts
+import { consumeIdentifierLike } from './utils.js';
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UnicodeEscapeIdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const start = stream.getPosition();
+  const value = consumeIdentifierLike(stream, { unicode: true, allowEscape: true });
+  if (value === null) return null;
+  return factory('IDENTIFIER', value, start, stream.getPosition());
+}


### PR DESCRIPTION
## Summary
- add TypeScript versions of `ByteOrderMarkReader`, `ShebangReader`, and `UnicodeEscapeIdentifierReader`
- maintain JS reader imports

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859c76dfce483319bf3aabfe69f6c68