### PR TITLE
[agent] Convert ByteOrderMarkReader to TS

### DIFF
--- a/src/lexer/ByteOrderMarkReader.ts
+++ b/src/lexer/ByteOrderMarkReader.ts
@@ -1,0 +1,21 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: unknown,
+  end: unknown
+) => Token;
+
+export function ByteOrderMarkReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '\uFEFF') return null;
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('BOM', '\uFEFF', startPos, endPos);
+}


### PR DESCRIPTION
## Summary
- convert `ByteOrderMarkReader` to TypeScript

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859c76dfce483319bf3aabfe69f6c68