### PR TITLE
[agent] chore(ts): add TypeScript versions of lexer utilities

### DIFF
--- a/fileStructure.txt
+++ b/fileStructure.txt
@@ -11,83 +11,129 @@
 ├── package.json
 ├── src
 │   ├── grammar
-│   │   └── JavaScriptGrammar.js
+│   │   ├── JavaScriptGrammar.js
+│   │   └── JavaScriptGrammar.ts
 │   ├── index.js
 │   ├── integration
 │   │   ├── BaseIncrementalLexer.js
+│   │   ├── BaseIncrementalLexer.ts
 │   │   ├── BufferedIncrementalLexer.js
+│   │   ├── BufferedIncrementalLexer.ts
 │   │   ├── IncrementalLexer.js
+│   │   ├── IncrementalLexer.ts
 │   │   ├── TokenStream.js
+│   │   ├── TokenStream.ts
 │   │   ├── stateUtils.js
-│   │   └── tokenUtils.js
+│   │   ├── stateUtils.ts
+│   │   ├── tokenUtils.js
+│   │   └── tokenUtils.ts
 │   ├── lexer
 │   │   ├── BindOperatorReader.js
+│   │   ├── BindOperatorReader.ts
 │   │   ├── ByteOrderMarkReader.js
+│   │   ├── ByteOrderMarkReader.ts
 │   │   ├── CharStream.js
+│   │   ├── CharStream.ts
 │   │   ├── CommentReader.js
+│   │   ├── CommentReader.ts
 │   │   ├── DoExpressionReader.js
 │   │   ├── FunctionSentReader.js
 │   │   ├── HTMLCommentReader.js
+│   │   ├── HTMLCommentReader.ts
 │   │   ├── IdentifierReader.js
+│   │   ├── IdentifierReader.ts
 │   │   ├── ImportAssertionReader.js
 │   │   ├── ImportCallReader.js
 │   │   ├── ImportMetaReader.js
+│   │   ├── ImportMetaReader.ts
 │   │   ├── JSXReader.js
 │   │   ├── LexerEngine.js
+│   │   ├── LexerEngine.ts
 │   │   ├── LexerError.js
+│   │   ├── LexerError.ts
 │   │   ├── ModuleBlockReader.js
 │   │   ├── OperatorReader.js
 │   │   ├── PatternMatchReader.js
 │   │   ├── PipelineOperatorReader.js
+│   │   ├── PipelineOperatorReader.ts
 │   │   ├── PrivateIdentifierReader.js
 │   │   ├── PunctuationReader.js
+│   │   ├── PunctuationReader.ts
 │   │   ├── RecordAndTupleReader.js
 │   │   ├── RegexOrDivideReader.js
 │   │   ├── ShebangReader.js
+│   │   ├── ShebangReader.ts
 │   │   ├── SourceMappingURLReader.js
 │   │   ├── StringReader.js
 │   │   ├── TemplateStringReader.js
 │   │   ├── Token.js
+│   │   ├── Token.ts
 │   │   ├── TokenReader.js
+│   │   ├── TokenReader.ts
 │   │   ├── UnicodeEscapeIdentifierReader.js
+│   │   ├── UnicodeEscapeIdentifierReader.ts
 │   │   ├── UnicodeIdentifierReader.js
+│   │   ├── UnicodeIdentifierReader.ts
 │   │   ├── UnicodeWhitespaceReader.js
+│   │   ├── UnicodeWhitespaceReader.ts
 │   │   ├── UsingStatementReader.js
+│   │   ├── UsingStatementReader.ts
 │   │   ├── WhitespaceReader.js
+│   │   ├── WhitespaceReader.ts
 │   │   ├── defaultReaders.js
+│   │   ├── defaultReaders.ts
 │   │   ├── number
 │   │   │   ├── BigIntReader.js
+│   │   │   ├── BigIntReader.ts
 │   │   │   ├── BinaryReader.js
+│   │   │   ├── BinaryReader.ts
 │   │   │   ├── DecimalLiteralReader.js
+│   │   │   ├── DecimalLiteralReader.ts
 │   │   │   ├── ExponentReader.js
+│   │   │   ├── ExponentReader.ts
 │   │   │   ├── HexReader.js
+│   │   │   ├── HexReader.ts
 │   │   │   ├── NumberReader.js
+│   │   │   ├── NumberReader.ts
 │   │   │   ├── NumericSeparatorReader.js
+│   │   │   ├── NumericSeparatorReader.ts
 │   │   │   ├── OctalReader.js
-│   │   │   └── RadixReader.js
+│   │   │   ├── OctalReader.ts
+│   │   │   ├── RadixReader.js
+│   │   │   └── RadixReader.ts
 │   │   └── utils.js
 │   ├── pluginManager.js
+│   ├── pluginManager.ts
 │   ├── plugins
 │   │   ├── DecoratorPlugin.js
+│   │   ├── DecoratorPlugin.ts
 │   │   ├── common
 │   │   │   ├── TSDecoratorReader.js
-│   │   │   └── TypeAnnotationReader.js
+│   │   │   ├── TSDecoratorReader.ts
+│   │   │   ├── TypeAnnotationReader.js
+│   │   │   └── TypeAnnotationReader.ts
 │   │   ├── flow
 │   │   │   └── FlowTypePlugin.js
 │   │   ├── importmeta
-│   │   │   └── ImportMetaPlugin.js
+│   │   │   ├── ImportMetaPlugin.js
+│   │   │   └── ImportMetaPlugin.ts
 │   │   └── typescript
 │   │       └── TypeScriptPlugin.js
 │   └── utils
 │       ├── checkCoverage.js
+│       ├── checkCoverage.ts
 │       ├── diagnostics.js
-│       └── tokenAnalysis.js
+│       ├── diagnostics.ts
+│       ├── tokenAnalysis.js
+│       └── tokenAnalysis.ts
 ├── tests
 │   ├── BaseIncrementalLexer.test.js
 │   ├── BufferedIncrementalLexer.test.js
 │   ├── TokenReader.test.js
 │   ├── benchmarks
-│   │   └── lexer.bench.js
+│   │   ├── lexer.bench.js
+│   │   ├── readers.bench.js
+│   │   └── realworld.bench.js
 │   ├── checkCoverage.test.js
 │   ├── cli.test.js
 │   ├── customFactory.test.js

--- a/src/lexer/TokenReader.ts
+++ b/src/lexer/TokenReader.ts
@@ -1,0 +1,29 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export type Reader = (
+  stream: CharStream,
+  factory: TokenFactory,
+  engine?: any
+) => Token | null;
+
+export function runReader(
+  reader: Reader,
+  stream: CharStream,
+  factory: TokenFactory,
+  engine?: any
+): Token | null {
+  if (typeof reader !== 'function') {
+    throw new TypeError(
+      `Reader must be a function, received ${typeof reader}`
+    );
+  }
+  return reader(stream, factory, engine);
+}

--- a/src/lexer/UsingStatementReader.ts
+++ b/src/lexer/UsingStatementReader.ts
@@ -1,0 +1,44 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeKeyword } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UsingStatementReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+
+  const saved = stream.getPosition();
+  let endPos = consumeKeyword(stream, 'await');
+  if (endPos) {
+    let value = 'await';
+    if (!/\s/.test(stream.current() || '')) {
+      stream.setPosition(saved);
+    } else {
+      while (!stream.eof() && /\s/.test(stream.current() || '')) {
+        value += stream.current();
+        stream.advance();
+      }
+      const usingEnd = consumeKeyword(stream, 'using', { checkPrev: false });
+      if (usingEnd) {
+        value += 'using';
+        return factory('AWAIT_USING', value, startPos, usingEnd);
+      }
+      stream.setPosition(saved);
+    }
+  }
+
+  endPos = consumeKeyword(stream, 'using');
+  if (endPos) {
+    return factory('USING', 'using', startPos, endPos);
+  }
+
+  return null;
+}

--- a/src/lexer/defaultReaders.ts
+++ b/src/lexer/defaultReaders.ts
@@ -1,0 +1,76 @@
+// src/lexer/defaultReaders.ts
+import type { Reader } from './TokenReader.js';
+
+import { IdentifierReader } from './IdentifierReader.js';
+import { BinaryReader } from './number/BinaryReader.js';
+import { OctalReader } from './number/OctalReader.js';
+import { HexReader } from './number/HexReader.js';
+import { BigIntReader } from './number/BigIntReader.js';
+import { DecimalLiteralReader } from './number/DecimalLiteralReader.js';
+import { NumericSeparatorReader } from './number/NumericSeparatorReader.js';
+import { ExponentReader } from './number/ExponentReader.js';
+import { NumberReader } from './number/NumberReader.js';
+import { StringReader } from './StringReader.js';
+import { RegexOrDivideReader } from './RegexOrDivideReader.js';
+import { BindOperatorReader } from './BindOperatorReader.js';
+import { PipelineOperatorReader } from './PipelineOperatorReader.js';
+import { OperatorReader } from './OperatorReader.js';
+import { PunctuationReader } from './PunctuationReader.js';
+import { TemplateStringReader } from './TemplateStringReader.js';
+import { JSXReader } from './JSXReader.js';
+import { CommentReader } from './CommentReader.js';
+import { HTMLCommentReader } from './HTMLCommentReader.js';
+import { SourceMappingURLReader } from './SourceMappingURLReader.js';
+import { UnicodeWhitespaceReader } from './UnicodeWhitespaceReader.js';
+import { ByteOrderMarkReader } from './ByteOrderMarkReader.js';
+import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
+import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
+import { ShebangReader } from './ShebangReader.js';
+import { DoExpressionReader } from './DoExpressionReader.js';
+import { ModuleBlockReader } from './ModuleBlockReader.js';
+import { UsingStatementReader } from './UsingStatementReader.js';
+import { PatternMatchReader } from './PatternMatchReader.js';
+import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
+import { ImportAssertionReader } from './ImportAssertionReader.js';
+import { RecordAndTupleReader } from './RecordAndTupleReader.js';
+import { FunctionSentReader } from './FunctionSentReader.js';
+
+/**
+ * Ordered list of built-in lexer readers.
+ * All entries are now *functions* conforming to the reader contract v2.
+ */
+export const baseReaders: Reader[] = [
+  HTMLCommentReader,
+  SourceMappingURLReader,
+  CommentReader,
+  UnicodeWhitespaceReader,
+  ByteOrderMarkReader,
+  ShebangReader,
+  PrivateIdentifierReader,
+  DoExpressionReader,
+  ModuleBlockReader,
+  UsingStatementReader,
+  PatternMatchReader,
+  FunctionSentReader,
+  ImportAssertionReader,
+  RecordAndTupleReader,
+  IdentifierReader,
+  UnicodeIdentifierReader,
+  UnicodeEscapeIdentifierReader,
+  HexReader,
+  BinaryReader,
+  OctalReader,
+  BigIntReader,
+  DecimalLiteralReader,
+  NumericSeparatorReader,
+  ExponentReader,
+  NumberReader,
+  StringReader,
+  RegexOrDivideReader,
+  PipelineOperatorReader,
+  BindOperatorReader,
+  OperatorReader,
+  PunctuationReader,
+  TemplateStringReader,
+  JSXReader
+];


### PR DESCRIPTION
## Summary
- add `UsingStatementReader.ts`
- add `TokenReader.ts`
- add `defaultReaders.ts`
- update `fileStructure.txt`

Approximately **41.5%** of modules are now written in TypeScript.

## Testing
- `yarn run lint`
- `yarn run test --silent --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859cb16fb7483319db0a3a2debc3ccf