### PR TITLE
[agent] feat: add TS readers

### DIFF
--- a/src/lexer/FunctionSentReader.ts
+++ b/src/lexer/FunctionSentReader.ts
@@ -1,0 +1,40 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function FunctionSentReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const prevIndex = startPos.index - 1;
+  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
+  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+
+  const seq = 'function.sent';
+  if (!stream.input.startsWith(seq, startPos.index)) return null;
+
+  const saved = stream.getPosition();
+  for (const ch of seq) {
+    if (stream.current() !== ch) {
+      stream.setPosition(saved);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next && /[A-Za-z0-9_$]/.test(next)) {
+    stream.setPosition(saved);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('FUNCTION_SENT', seq, startPos, endPos);
+}

--- a/src/lexer/ImportCallReader.ts
+++ b/src/lexer/ImportCallReader.ts
@@ -1,0 +1,27 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeKeyword } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ImportCallReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const endPos = consumeKeyword(stream, 'import');
+  if (!endPos) return null;
+
+  // confirm '(' but don't consume
+  if (stream.current() !== '(') {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  return factory('IMPORT_CALL', 'import', startPos, endPos);
+}

--- a/src/lexer/PrivateIdentifierReader.ts
+++ b/src/lexer/PrivateIdentifierReader.ts
@@ -1,0 +1,34 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function PrivateIdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  stream.advance();
+  let ch = stream.current();
+  if (ch === null || !(/[A-Za-z_]/.test(ch))) {
+    stream.setPosition(startPos);
+    return null;
+  }
+  let value = '#';
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+  while (ch !== null && /[A-Za-z0-9_]/.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const endPos = stream.getPosition();
+  return factory('PRIVATE_IDENTIFIER', value, startPos, endPos);
+}

--- a/src/lexer/SourceMappingURLReader.ts
+++ b/src/lexer/SourceMappingURLReader.ts
@@ -1,0 +1,48 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function SourceMappingURLReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const start = stream.getPosition();
+  const patterns = [
+    '//# sourceMappingURL=',
+    '//@ sourceMappingURL=',
+    '/*# sourceMappingURL=',
+    '/*@ sourceMappingURL=',
+  ];
+
+  for (const p of patterns) if (stream.input.startsWith(p, stream.index)) {
+    const isBlock = p.startsWith('/*');
+    for (let i = 0; i < p.length; i++) stream.advance();
+    const buf: string[] = [];
+    if (isBlock) {
+      while (
+        !stream.eof() &&
+        !(stream.current() === '*' && stream.peek() === '/')
+      ) {
+        buf.push(stream.current() as string);
+        stream.advance();
+      }
+      if (stream.current() === '*' && stream.peek() === '/') {
+        stream.advance();
+        stream.advance();
+      }
+    } else {
+      while (!stream.eof() && stream.current() !== '\n') {
+        buf.push(stream.current() as string);
+        stream.advance();
+      }
+    }
+    return factory('SOURCE_MAPPING_URL', buf.join('').trim(), start, stream.getPosition());
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- convert several lexer modules to TypeScript
- include FunctionSentReader, ImportCallReader, PrivateIdentifierReader and SourceMappingURLReader

## Testing
- `yarn --silent lint`
- `yarn --silent test -- --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859cb16fb7483319db0a3a2debc3ccf