### PR TITLE
[agent] feat: add TypeScript readers

### DIFF
--- a/src/lexer/ModuleBlockReader.ts
+++ b/src/lexer/ModuleBlockReader.ts
@@ -1,0 +1,66 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ModuleBlockReader(
+  stream: CharStream,
+  factory: TokenFactory,
+  engine?: any
+): Token | null {
+  const startPos = stream.getPosition();
+
+  if (engine && engine.currentMode && engine.currentMode() === 'module_block') {
+    if (stream.current() === '{') {
+      engine.moduleBlockDepth = (engine.moduleBlockDepth || 0) + 1;
+      return null;
+    }
+    if (stream.current() === '}') {
+      if (engine.moduleBlockDepth > 0) {
+        engine.moduleBlockDepth--;
+        return null;
+      }
+      stream.advance();
+      const endPos = stream.getPosition();
+      engine.popMode();
+      return factory('MODULE_BLOCK_END', '}', startPos, endPos);
+    }
+  }
+
+  if (!stream.input.startsWith('module', stream.index)) return null;
+
+  const savedPos = stream.getPosition();
+  for (const ch of 'module') {
+    if (stream.current() !== ch) {
+      stream.setPosition(savedPos);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next !== '{' && !(/\s/.test(next))) {
+    stream.setPosition(savedPos);
+    return null;
+  }
+
+  while (!stream.eof() && /\s/.test(stream.current())) {
+    stream.advance();
+  }
+
+  if (stream.current() !== '{') {
+    stream.setPosition(savedPos);
+    return null;
+  }
+
+  stream.advance();
+  engine && engine.pushMode && engine.pushMode('module_block');
+  engine.moduleBlockDepth = 0;
+  const endPos = stream.getPosition();
+  return factory('MODULE_BLOCK_START', 'module {', startPos, endPos);
+}

--- a/src/lexer/PatternMatchReader.ts
+++ b/src/lexer/PatternMatchReader.ts
@@ -1,0 +1,57 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function PatternMatchReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const prevIndex = startPos.index - 1;
+  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
+  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+
+  if (stream.input.startsWith('match', stream.index)) {
+    const saved = stream.getPosition();
+    for (const ch of 'match') {
+      if (stream.current() !== ch) {
+        stream.setPosition(saved);
+        return null;
+      }
+      stream.advance();
+    }
+    const next = stream.current();
+    if (next && /[A-Za-z0-9_$]/.test(next)) {
+      stream.setPosition(saved);
+      return null;
+    }
+    const endPos = stream.getPosition();
+    return factory('MATCH', 'match', startPos, endPos);
+  }
+
+  if (stream.input.startsWith('case', stream.index)) {
+    const saved = stream.getPosition();
+    for (const ch of 'case') {
+      if (stream.current() !== ch) {
+        stream.setPosition(saved);
+        return null;
+      }
+      stream.advance();
+    }
+    const next = stream.current();
+    if (next && /[A-Za-z0-9_$]/.test(next)) {
+      stream.setPosition(saved);
+      return null;
+    }
+    const endPos = stream.getPosition();
+    return factory('CASE', 'case', startPos, endPos);
+  }
+
+  return null;
+}

--- a/src/lexer/PrivateIdentifierReader.ts
+++ b/src/lexer/PrivateIdentifierReader.ts
@@ -1,0 +1,34 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function PrivateIdentifierReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  stream.advance();
+  let ch = stream.current() as string | null;
+  if (ch === null || !(/[A-Za-z_]/.test(ch))) {
+    stream.setPosition(startPos);
+    return null;
+  }
+  let value = '#';
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+  while (ch !== null && /[A-Za-z0-9_]/.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const endPos = stream.getPosition();
+  return factory('PRIVATE_IDENTIFIER', value, startPos, endPos);
+}

--- a/src/lexer/UsingStatementReader.ts
+++ b/src/lexer/UsingStatementReader.ts
@@ -1,0 +1,45 @@
+import { consumeKeyword } from './utils.js';
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function UsingStatementReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+
+  // await using
+  const saved = stream.getPosition();
+  let endPos = consumeKeyword(stream, 'await');
+  if (endPos) {
+    let value = 'await';
+    if (!/\s/.test(stream.current())) {
+      stream.setPosition(saved);
+    } else {
+      while (!stream.eof() && /\s/.test(stream.current())) {
+        value += stream.current();
+        stream.advance();
+      }
+      const usingEnd = consumeKeyword(stream, 'using', { checkPrev: false });
+      if (usingEnd) {
+        value += 'using';
+        return factory('AWAIT_USING', value, startPos, usingEnd);
+      }
+      stream.setPosition(saved);
+    }
+  }
+
+  endPos = consumeKeyword(stream, 'using');
+  if (endPos) {
+    return factory('USING', 'using', startPos, endPos);
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add TypeScript versions of `PrivateIdentifierReader`, `UsingStatementReader`, `ModuleBlockReader` and `PatternMatchReader`
- keep existing `.js` files for compatibility

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_6859ce58b6888331a42ca3a23af9957c