### PR TITLE
[agent] Add TypeScript counterparts for all modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { CharStream } from './lexer/CharStream.js';
+import { LexerEngine } from './lexer/LexerEngine.js';
+import { IncrementalLexer } from './integration/IncrementalLexer.js';
+import { BufferedIncrementalLexer } from './integration/BufferedIncrementalLexer.js';
+import { createTokenStream, TokenStream } from './integration/TokenStream.js';
+import { tokenIterator } from './integration/tokenUtils.js';
+import { fileURLToPath } from 'url';
+import { registerPlugin, clearPlugins } from './pluginManager.js';
+import type { Token } from './lexer/Token.js';
+
+export interface TokenizeOptions {
+  verbose?: boolean;
+  errorRecovery?: boolean;
+  sourceURL?: string | null;
+}
+
+export function tokenize(
+  code: string,
+  { verbose = false, errorRecovery = false, sourceURL = null }: TokenizeOptions = {}
+): Token[] {
+  const stream = new CharStream(code, { sourceURL });
+  const lexer = new LexerEngine(stream, { errorRecovery });
+  const tokens: Token[] = [];
+  for (const tok of tokenIterator(lexer)) {
+    tokens.push(tok as Token);
+    if (verbose) console.log(tok);
+  }
+  return tokens;
+}
+
+export { IncrementalLexer, BufferedIncrementalLexer, TokenStream, createTokenStream };
+export { registerPlugin, clearPlugins };
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const input = process.argv[2] || '';
+  const verbose = process.argv.includes('--verbose');
+  try {
+    console.log(tokenize(input, { verbose }));
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}

--- a/src/lexer/ImportCallReader.ts
+++ b/src/lexer/ImportCallReader.ts
@@ -1,0 +1,26 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { consumeKeyword } from './utils.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function ImportCallReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  const endPos = consumeKeyword(stream, 'import');
+  if (!endPos) return null;
+
+  if (stream.current() !== '(') {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  return factory('IMPORT_CALL', 'import', startPos, endPos);
+}

--- a/src/lexer/OperatorReader.ts
+++ b/src/lexer/OperatorReader.ts
@@ -1,0 +1,27 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+const ops = JavaScriptGrammar.sortedOperators;
+
+export function OperatorReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  for (const op of ops) {
+    if (stream.input.startsWith(op, stream.index)) {
+      for (let i = 0; i < op.length; i++) stream.advance();
+      const endPos = stream.getPosition();
+      return factory('OPERATOR', op, startPos, endPos);
+    }
+  }
+  return null;
+}

--- a/src/lexer/RecordAndTupleReader.ts
+++ b/src/lexer/RecordAndTupleReader.ts
@@ -1,0 +1,25 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function RecordAndTupleReader(
+  stream: CharStream,
+  factory: TokenFactory
+): Token | null {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  const next = stream.peek();
+  if (next !== '{' && next !== '[') return null;
+  stream.advance();
+  stream.advance();
+  const endPos = stream.getPosition();
+  const type = next === '{' ? 'RECORD_START' : 'TUPLE_START';
+  const value = next === '{' ? '#{' : '#[';
+  return factory(type, value, startPos, endPos);
+}

--- a/src/lexer/RegexOrDivideReader.ts
+++ b/src/lexer/RegexOrDivideReader.ts
@@ -1,0 +1,159 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import matchProp from 'unicode-match-property-ecmascript';
+import matchPropValue from 'unicode-match-property-value-ecmascript';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export interface RegexReaderOpts {
+  validateUnicodeProperties?: boolean;
+}
+
+const WS = new Set([' ', '\t', '\n', '\r', '\v', '\f']);
+const STARTS = new Set([
+  '(', '{', '[', '=', ':', ',', ';', '!', '?', '+',
+  '-', '*', '%', '&', '|', '^', '~', '<', '>'
+]);
+
+const inRegexContext = (stream: CharStream, at: number): boolean => {
+  let i = at - 1;
+  while (i >= 0 && WS.has(stream.input[i]!)) i--;
+  return i < 0 || STARTS.has(stream.input[i]!);
+};
+
+const makeOp = (
+  stream: CharStream,
+  f: TokenFactory,
+  start: any,
+  val: string
+): Token => {
+  for (let i = 0; i < val.length; i++) stream.advance();
+  return f('OPERATOR', val, start, stream.getPosition());
+};
+
+const validateUnicodeProp = (expr: string): void => {
+  const sep = expr.indexOf('=');
+  if (sep !== -1) {
+    const prop = matchProp(expr.slice(0, sep));
+    matchPropValue(prop, expr.slice(sep + 1));
+  } else {
+    try { matchProp(expr); }
+    catch { matchPropValue('General_Category', expr); }
+  }
+};
+
+function readRegexLiteral(
+  stream: CharStream,
+  f: TokenFactory,
+  start: any,
+  opts?: RegexReaderOpts
+): Token | null {
+  stream.advance();
+
+  const body: string[] = [];
+  let esc = false;
+  let depth = 0;
+
+  while (!stream.eof()) {
+    const ch = stream.current()!;
+
+    if (esc) {
+      body.push(ch);
+      stream.advance();
+      esc = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      const next = stream.peek();
+
+      if ((next === 'p' || next === 'P') && stream.peek(2) === '{') {
+        body.push('\\', next!, '{');
+        stream.advance();
+        stream.advance();
+        stream.advance();
+
+        const prop: string[] = [];
+        while (!stream.eof() && stream.current() !== '}') {
+          const c = stream.current()!;
+          if (!/[A-Za-z0-9_=^:-]/.test(c)) {
+            return f('INVALID_REGEX', `/${body.join('')}`, start, stream.getPosition());
+          }
+          prop.push(c);
+          body.push(c);
+          stream.advance();
+        }
+        if (stream.current() !== '}') {
+          return f('INVALID_REGEX', `/${body.join('')}`, start, stream.getPosition());
+        }
+        body.push('}');
+        stream.advance();
+
+        if (opts?.validateUnicodeProperties) {
+          try { validateUnicodeProp(prop.join('').replace(/^\^/, '')); }
+          catch {
+            return f('INVALID_REGEX', `/${body.join('')}`, start, stream.getPosition());
+          }
+        }
+        continue;
+      }
+
+      esc = true;
+      body.push('\\');
+      stream.advance();
+      continue;
+    }
+
+    if (ch === '[') depth++;
+    else if (ch === ']') depth = Math.max(0, depth - 1);
+    else if (ch === '/' && depth === 0) break;
+
+    body.push(ch);
+    stream.advance();
+  }
+
+  if (depth !== 0 || stream.current() !== '/') {
+    return f('INVALID_REGEX', `/${body.join('')}`, start, stream.getPosition());
+  }
+
+  stream.advance();
+
+  const flags: string[] = [];
+  while (!stream.eof() && /[A-Za-z]/.test(stream.current()!)) {
+    flags.push(stream.current()!);
+    stream.advance();
+  }
+
+  const bodyStr = body.join('');
+  const flagStr = flags.join('');
+
+  if (/\(\?<\d/.test(bodyStr)) {
+    return f('INVALID_REGEX', `/${bodyStr}/${flagStr}`, start, stream.getPosition());
+  }
+
+  return f('REGEX', `/${bodyStr}/${flagStr}`, start, stream.getPosition());
+}
+
+export function RegexOrDivideReader(
+  stream: CharStream,
+  factory: TokenFactory,
+  opts?: RegexReaderOpts
+): Token | null {
+  const start = stream.getPosition();
+  if (stream.current() !== '/') return null;
+
+  if (stream.peek() === '=') {
+    return makeOp(stream, factory, start, '/=');
+  }
+
+  if (!inRegexContext(stream, start.index)) {
+    return makeOp(stream, factory, start, '/');
+  }
+
+  return readRegexLiteral(stream, factory, start, opts);
+}

--- a/src/lexer/TemplateStringReader.ts
+++ b/src/lexer/TemplateStringReader.ts
@@ -1,0 +1,97 @@
+import type { CharStream } from './CharStream.js';
+import type { Token } from './Token.js';
+import { LexerError } from './LexerError.js';
+
+export type TokenFactory = (
+  type: string,
+  value: string,
+  start: any,
+  end: any
+) => Token;
+
+export function TemplateStringReader(
+  stream: CharStream,
+  factory: TokenFactory,
+  engine?: any
+): Token | LexerError | null {
+  if (stream.current() !== '`') return null;
+  const start = stream.getPosition();
+  const isHTML = engine?.lastToken?.type === 'IDENTIFIER' && engine.lastToken.value === 'html';
+
+  const buf: string[] = ['`'];
+  stream.advance();
+
+  while (!stream.eof()) {
+    const ch = stream.current()!;
+
+    if (ch === '\\') {
+      buf.push('\\');
+      stream.advance();
+      if (stream.eof()) return factory('INVALID_TEMPLATE_STRING', buf.join(''), start, stream.getPosition());
+      buf.push(stream.current()!);
+      stream.advance();
+      continue;
+    }
+
+    if (ch === '`') {
+      buf.push('`');
+      stream.advance();
+      const type = isHTML ? 'HTML_TEMPLATE_STRING' : 'TEMPLATE_STRING';
+      return factory(type, buf.join(''), start, stream.getPosition());
+    }
+
+    if (ch === '$' && stream.peek() === '{') {
+      buf.push('$', '{');
+      stream.advance();
+      stream.advance();
+      let depth = 1;
+      while (!stream.eof() && depth) {
+        const c = stream.current()!;
+
+        if (c === '\\') {
+          buf.push('\\');
+          stream.advance();
+          if (!stream.eof()) {
+            buf.push(stream.current()!);
+            stream.advance();
+          }
+          continue;
+        }
+        if (c === '"' || c === "'") {
+          const q = c;
+          buf.push(c);
+          stream.advance();
+          while (!stream.eof()) {
+            const qc = stream.current()!;
+            buf.push(qc);
+            stream.advance();
+            if (qc === '\\') {
+              if (!stream.eof()) {
+                buf.push(stream.current()!);
+                stream.advance();
+              }
+              continue;
+            }
+            if (qc === q) break;
+          }
+          continue;
+        }
+        if (c === '`') {
+          const nested = TemplateStringReader(stream, factory);
+          if (nested instanceof LexerError) return nested;
+          buf.push((nested as Token).value as string);
+          continue;
+        }
+        if (c === '{') depth++;
+        else if (c === '}') depth--;
+        buf.push(c);
+        stream.advance();
+      }
+      continue;
+    }
+
+    buf.push(ch);
+    stream.advance();
+  }
+  return new LexerError('UnterminatedTemplate','Unterminated template literal',start,stream.getPosition(),stream.input);
+}


### PR DESCRIPTION
## Summary
- provide `index.ts` for typed main API
- add TypeScript versions of remaining readers

## Testing
- `yarn lint`
- `yarn test --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859d03c9450833191ee0e6e46f12435