### PR TITLE
[agent] add prettier setup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}
+

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "check:coverage": "node src/utils/checkCoverage.js 90",
     "workflow": "yarn lint && yarn test --coverage && yarn check:coverage && node tests/benchmarks/lexer.bench.js && node tests/benchmarks/realworld.bench.js",
     "clean": "rimraf dist coverage .turbo && echo cleaned",
-    "upgrade": "yarn up \"*\" --latest"
+    "upgrade": "yarn up \"*\" --latest",
+    "format": "prettier --write ."
   },
   "keywords": [
     "lexer",
@@ -47,6 +48,7 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "nock": "^14.0.2",
+    "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,6 +1359,7 @@ __metadata:
     husky: "npm:^9.1.7"
     jest: "npm:^29.7.0"
     nock: "npm:^14.0.2"
+    prettier: "npm:^3.2.5"
     rimraf: "npm:^5.0.5"
     ts-jest: "npm:^29.4.0"
     typescript: "npm:^5.8.3"
@@ -4284,6 +4285,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.2.5":
+  version: 3.6.0
+  resolution: "prettier@npm:3.6.0"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/636897c8084b71ef1f740a46199df0d8f6ed896aa497212cc8cc229d3026b9dca82fa92f61e55924c4708cea11e39a88478e2d93c4818741c55b7408a9ac6d91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add `.prettierrc` with basic options
- include Prettier as a dev dependency and add a `format` script

## Testing
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6859eac66b208331a9c9ee24dc0f699e