### PR TITLE
[agent] chore: add prettier ignore and check script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Dependencies
+node_modules
+
+# Build output
+coverage
+dist
+
+# Yarn install state
+yarn.lock
+
+# Git directories
+.git
+.github/workflows/ci.yml

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "diag": "node ./src/utils/diagnostics.js",
     "diagnostics": "yarn diag",
     "check:coverage": "node src/utils/checkCoverage.js 90",
+    "format:check": "prettier --check .",
     "workflow": "yarn lint && yarn test --coverage && yarn check:coverage && node tests/benchmarks/lexer.bench.js && node tests/benchmarks/realworld.bench.js",
     "clean": "rimraf dist coverage .turbo && echo cleaned",
     "upgrade": "yarn up \"*\" --latest",


### PR DESCRIPTION
## Summary
- ignore unformatted directories for Prettier
- add a `format:check` script to spot formatting issues

## Testing
- `yarn run --silent lint`
- `yarn run --silent test`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_6859f10ed51c8331b64951620d438709