### PR TITLE
[agent] chore(package): use build output as main entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Added repository and bugs fields in package.json
 - Added TypeScript build configuration to start JS phase-out
+- Package main now points to built TypeScript output

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Lexinator",
   "version": "1.1.3",
   "description": "A modular, adaptive, experimental JavaScript lexer.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "type": "module",
   "packageManager": "yarn@4.9.2",
   "nodeLinker": "node-modules",
@@ -14,7 +14,7 @@
     "url": "https://github.com/jick666/Lexinator/issues"
   },
   "scripts": {
-    "start": "node src/index.js",
+    "start": "node dist/index.js",
     "lint": "eslint .",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.cjs --coverage",
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary
- point package main to built `dist` entry
- update changelog

## Testing
- `yarn workflow`

------
https://chatgpt.com/codex/tasks/task_e_685a11fd5780833194af0896b7654613