### PR TITLE
[agent] chore: enforce TypeScript-only sources

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Package main now points to built TypeScript output
 - Fully migrated source and tests to TypeScript
 - Converted remaining reader tests to TypeScript
+- Disabled allowJs to enforce TypeScript-only sources

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -11,10 +11,10 @@ module.exports = {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   collectCoverageFrom: [
-    'src/index.js',
-    'src/pluginManager.js',
-    'src/utils/**/*.js',
-    'src/plugins/**/*.js'
+    'src/index.ts',
+    'src/pluginManager.ts',
+    'src/utils/**/*.ts',
+    'src/plugins/**/*.ts'
   ],
   coverageDirectory: 'coverage'
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2020",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowJs": true,
+    "allowJs": false,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
- enforce TS-only build by disabling `allowJs`
- update Jest coverage patterns for `.ts`
- ignore dist and coverage in ESLint

## Testing
- `yarn lint`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685a1dba2f988331992ec8fa4b8cfa08