### PR TITLE
[agent] fix semantic release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       - run: yarn install --production --immutable
         name: Install production dependencies
 
-      - run: yarn semantic-release
+      - run: npx -y semantic-release
         name: Semantic Release
 
       - name: Upload new bench baseline


### PR DESCRIPTION
## Summary
- run `semantic-release` via npx to avoid missing dependency failures

## Testing
- `yarn workflow --silent`


------
https://chatgpt.com/codex/tasks/task_e_685a281b99b48331863fa15b2ff5a603