### PR TITLE
[agent] refactor readers to use consumeKeyword

### DIFF
--- a/src/lexer/ModuleBlockReader.js
+++ b/src/lexer/ModuleBlockReader.js
@@ -1,3 +1,5 @@
+import { consumeKeyword } from './utils.js';
+
 export function ModuleBlockReader(stream, factory, engine) {
   const startPos = stream.getPosition();
 
@@ -18,20 +20,12 @@ export function ModuleBlockReader(stream, factory, engine) {
     }
   }
 
-  if (!stream.input.startsWith('module', stream.index)) return null;
-
-  const savedPos = stream.getPosition();
-  for (const ch of 'module') {
-    if (stream.current() !== ch) {
-      stream.setPosition(savedPos);
-      return null;
-    }
-    stream.advance();
-  }
+  const kwEnd = consumeKeyword(stream, 'module');
+  if (!kwEnd) return null;
 
   const next = stream.current();
   if (next !== '{' && !(/\s/.test(next))) {
-    stream.setPosition(savedPos);
+    stream.setPosition(startPos);
     return null;
   }
 
@@ -40,7 +34,7 @@ export function ModuleBlockReader(stream, factory, engine) {
   }
 
   if (stream.current() !== '{') {
-    stream.setPosition(savedPos);
+    stream.setPosition(startPos);
     return null;
   }
 

--- a/src/lexer/PatternMatchReader.js
+++ b/src/lexer/PatternMatchReader.js
@@ -1,42 +1,15 @@
+import { consumeKeyword } from './utils.js';
+
 export function PatternMatchReader(stream, factory) {
   const startPos = stream.getPosition();
-  const prevIndex = startPos.index - 1;
-  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
-  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
 
-  if (stream.input.startsWith('match', stream.index)) {
-    const saved = stream.getPosition();
-    for (const ch of 'match') {
-      if (stream.current() !== ch) {
-        stream.setPosition(saved);
-        return null;
-      }
-      stream.advance();
-    }
-    const next = stream.current();
-    if (next && /[A-Za-z0-9_$]/.test(next)) {
-      stream.setPosition(saved);
-      return null;
-    }
-    const endPos = stream.getPosition();
+  let endPos = consumeKeyword(stream, 'match');
+  if (endPos) {
     return factory('MATCH', 'match', startPos, endPos);
   }
 
-  if (stream.input.startsWith('case', stream.index)) {
-    const saved = stream.getPosition();
-    for (const ch of 'case') {
-      if (stream.current() !== ch) {
-        stream.setPosition(saved);
-        return null;
-      }
-      stream.advance();
-    }
-    const next = stream.current();
-    if (next && /[A-Za-z0-9_$]/.test(next)) {
-      stream.setPosition(saved);
-      return null;
-    }
-    const endPos = stream.getPosition();
+  endPos = consumeKeyword(stream, 'case');
+  if (endPos) {
     return factory('CASE', 'case', startPos, endPos);
   }
 


### PR DESCRIPTION
## Summary
- deduplicate keyword matching logic using `consumeKeyword`
- update ImportAssertionReader, ModuleBlockReader and PatternMatchReader

## Testing
- `yarn lint`
- `yarn test --silent`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_685a2e4c86688331b1a562dfce57559c