### PR TITLE
[agent] refactor trivia handling

### DIFF
--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -2,6 +2,7 @@
 
 import { BaseIncrementalLexer } from './BaseIncrementalLexer.js';
 import { LexerError } from '../lexer/LexerError.js';
+import { processToken } from './tokenUtils.js';
 
 function isIncompleteBlockComment(token, stream) {
   return (
@@ -45,19 +46,10 @@ export class BufferedIncrementalLexer extends BaseIncrementalLexer {
         break;
       }
 
-      // Trivia handling with lazy allocation.
-      if (token.type === 'WHITESPACE') {
-        this.trivia.push(token);
-        continue;
-      }
-
-      if (this.trivia.length) token.attachLeading(this.trivia);
-      if (this.tokens.length && this.trivia.length) {
-        this.tokens[this.tokens.length - 1].attachTrailing(this.trivia);
-      }
-      this.trivia = [];
-
-      this.emit(token);
+      const prev = this.tokens.length ? this.tokens[this.tokens.length - 1] : null;
+      const out = processToken(token, this.trivia, prev);
+      if (!out) continue;
+      this.emit(out);
     }
   }
 

--- a/src/integration/tokenUtils.js
+++ b/src/integration/tokenUtils.js
@@ -1,8 +1,21 @@
 // src/integration/tokenUtils.js
 
+export function processToken(token, trivia, prev) {
+  if (token.type === 'WHITESPACE') {
+    trivia.push(token);
+    return null;
+  }
+
+  if (trivia.length) token.attachLeading([...trivia]);
+  if (prev && trivia.length) prev.attachTrailing([...trivia]);
+
+  trivia.length = 0;
+  return token;
+}
+
 export function* tokenIterator(engine) {
-  let trivia = [];
-  let prev   = null;
+  const trivia = [];
+  let prev = null;
 
   while (true) {
     const tok = engine.nextToken();
@@ -11,17 +24,11 @@ export function* tokenIterator(engine) {
       return;
     }
 
-    if (tok.type === 'WHITESPACE') {
-      trivia.push(tok);
-      continue;
-    }
+    const out = processToken(tok, trivia, prev);
+    if (!out) continue;
 
-    if (trivia.length) tok.attachLeading(trivia);
-    if (prev && trivia.length) prev.attachTrailing(trivia);
-
-    trivia = [];
-    prev   = tok;
-    yield tok;
+    prev = out;
+    yield out;
   }
 }
 


### PR DESCRIPTION
## Summary
- centralize whitespace and trivia processing
- use the helper in `BufferedIncrementalLexer`

## Testing
- `yarn lint`
- `yarn test --silent --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_685a30e853508331a72767a1eba94e6e