### PR TITLE
[agent] refactor plugins for DRYness

### DIFF
--- a/src/plugins/DecoratorPlugin.js
+++ b/src/plugins/DecoratorPlugin.js
@@ -1,8 +1,4 @@
 import { TSDecoratorReader } from './common/TSDecoratorReader.js';
+import { createPlugin } from './pluginUtils.js';
 
-export const DecoratorPlugin = {
-  modes: { default: [TSDecoratorReader] },
-  init() {
-    // plugin hook for future engine tweaks
-  }
-};
+export const DecoratorPlugin = createPlugin([TSDecoratorReader]);

--- a/src/plugins/flow/FlowTypePlugin.js
+++ b/src/plugins/flow/FlowTypePlugin.js
@@ -1,17 +1,11 @@
 // src/plugins/flow/FlowTypePlugin.js
 
 import { createTypeAnnotationReader } from '../common/TypeAnnotationReader.js';
+import { createPlugin } from '../pluginUtils.js';
 
 /** Flow type-annotation reader (allows “?” in the annotation). */
 export const FlowTypeAnnotationReader = createTypeAnnotationReader({
   allowQuestionMark: true
 });
 
-export const FlowTypePlugin = {
-  // Declarative reader list (still appended so Flow can run without init())
-  modes: { default: [FlowTypeAnnotationReader] },
-
-  init(engine) {
-    engine.addReaders('default', FlowTypeAnnotationReader);
-  }
-};
+export const FlowTypePlugin = createPlugin([FlowTypeAnnotationReader]);

--- a/src/plugins/importmeta/ImportMetaPlugin.js
+++ b/src/plugins/importmeta/ImportMetaPlugin.js
@@ -2,12 +2,9 @@
 
 import { ImportMetaReader } from '../../lexer/ImportMetaReader.js';
 import { ImportCallReader } from '../../lexer/ImportCallReader.js';
+import { createPlugin } from '../pluginUtils.js';
 
-export const ImportMetaPlugin = {
-  // Declarative reader list (fallback)
-  modes: { default: [ImportMetaReader, ImportCallReader] },
-
-  init(engine) {
-    engine.addReaders('default', ImportMetaReader, ImportCallReader);
-  }
-};
+export const ImportMetaPlugin = createPlugin([
+  ImportMetaReader,
+  ImportCallReader
+]);

--- a/src/plugins/pluginUtils.js
+++ b/src/plugins/pluginUtils.js
@@ -1,0 +1,9 @@
+export function createPlugin(readers, extraInit) {
+  return {
+    modes: { default: readers },
+    init(engine) {
+      engine.addReaders('default', ...readers);
+      if (typeof extraInit === 'function') extraInit(engine);
+    }
+  };
+}

--- a/src/plugins/typescript/TypeScriptPlugin.js
+++ b/src/plugins/typescript/TypeScriptPlugin.js
@@ -2,6 +2,7 @@
 
 import { TSDecoratorReader } from '../common/TSDecoratorReader.js';
 import { createTypeAnnotationReader } from '../common/TypeAnnotationReader.js';
+import { createPlugin } from '../pluginUtils.js';
 
 export const TSTypeAnnotationReader = createTypeAnnotationReader();
 
@@ -27,18 +28,9 @@ export function TSGenericParameterReader(stream, factory) {
   return factory('TYPE_PARAMETER', value, start, stream.getPosition());
 }
 
-export const TypeScriptPlugin = {
-  modes: {
-    default: [TSDecoratorReader, TSTypeAnnotationReader, TSGenericParameterReader]
-  },
-
-  init(engine) {
+export const TypeScriptPlugin = createPlugin(
+  [TSDecoratorReader, TSTypeAnnotationReader, TSGenericParameterReader],
+  engine => {
     engine.disableJsx = true;
-    engine.addReaders(
-      'default',
-      TSDecoratorReader,
-      TSTypeAnnotationReader,
-      TSGenericParameterReader
-    );
   }
-};
+);


### PR DESCRIPTION
## Summary
- reduce duplication by adding `createPlugin`
- refactor built-in plugins to use the helper

## Testing
- `yarn lint --silent` *(fails: Invalid option '--silent')*
- `yarn test --silent -- --coverage` *(fails: No tests found)*
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_685a30e853508331a72767a1eba94e6e