### PR TITLE
[agent] refactor identifier readers

### DIFF
--- a/src/lexer/IdentifierReader.js
+++ b/src/lexer/IdentifierReader.js
@@ -1,12 +1,5 @@
 // src/lexer/IdentifierReader.js
 
-import { consumeIdentifierLike } from './utils.js';
-
-export function IdentifierReader(stream, factory) {
-  const start = stream.getPosition();
-  const value = consumeIdentifierLike(stream, { unicode: false });
-  if (value === null) return null;
-  return factory('IDENTIFIER', value, start, stream.getPosition());
-}
-
+import { makeIdentifierReader } from './utils.js';
+export const IdentifierReader = makeIdentifierReader({ unicode: false });
 export const IdentifierReaderClass = IdentifierReader;

--- a/src/lexer/UnicodeEscapeIdentifierReader.js
+++ b/src/lexer/UnicodeEscapeIdentifierReader.js
@@ -1,10 +1,5 @@
 // src/lexer/UnicodeEscapeIdentifierReader.js
 
-import { consumeIdentifierLike } from './utils.js';
+import { makeIdentifierReader } from './utils.js';
 
-export function UnicodeEscapeIdentifierReader(stream, factory) {
-  const start = stream.getPosition();
-  const value = consumeIdentifierLike(stream, { unicode: true, allowEscape: true });
-  if (value === null) return null;
-  return factory('IDENTIFIER', value, start, stream.getPosition());
-}
+export const UnicodeEscapeIdentifierReader = makeIdentifierReader({ unicode: true, allowEscape: true });

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,13 +1,5 @@
 // src/lexer/UnicodeIdentifierReader.js
 
-import { consumeIdentifierLike } from './utils.js';
+import { makeIdentifierReader } from './utils.js';
 
-export function UnicodeIdentifierReader(stream, factory) {
-  // Fast bail-out: ASCII handled by IdentifierReader.
-  if (stream.current() === null || stream.current().charCodeAt(0) < 128) return null;
-
-  const start = stream.getPosition();
-  const value = consumeIdentifierLike(stream, { unicode: true });
-  if (value === null) return null;
-  return factory('IDENTIFIER', value, start, stream.getPosition());
-}
+export const UnicodeIdentifierReader = makeIdentifierReader({ unicode: true, bailASCII: true });

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -124,3 +124,16 @@ export function consumeKeyword(stream, kw, { checkPrev = true } = {}) {
   if (/[A-Za-z0-9_$]/.test(stream.current() || '')) { stream.setPosition(mark); return null; }
   return stream.getPosition();
 }
+
+/** Create an identifier reader with common logic */
+export function makeIdentifierReader({ unicode = false, allowEscape = false, bailASCII = false } = {}) {
+  return function identifierReader(stream, factory) {
+    if (bailASCII && (stream.current() === null || stream.current().charCodeAt(0) < 128)) {
+      return null;
+    }
+    const start = stream.getPosition();
+    const value = consumeIdentifierLike(stream, { unicode, allowEscape });
+    if (value === null) return null;
+    return factory('IDENTIFIER', value, start, stream.getPosition());
+  };
+}


### PR DESCRIPTION
## Summary
- add `makeIdentifierReader` utility for common identifier reader logic
- use generator in IdentifierReader, UnicodeIdentifierReader and UnicodeEscapeIdentifierReader

## Testing
- `yarn lint`
- `yarn test --silent`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_685a30e853508331a72767a1eba94e6e