### PR TITLE
[agent] refactor: centralize underscore validation

### DIFF
--- a/src/lexer/BigIntReader.js
+++ b/src/lexer/BigIntReader.js
@@ -1,4 +1,4 @@
-import { readDigitsWithUnderscores, isDigit } from './utils.js';
+import { readDigitsWithUnderscores, finalizeUnderscoredDigits, isDigit } from './utils.js';
 
 export function BigIntReader(stream, factory) {
   const startPos = stream.getPosition();
@@ -14,18 +14,9 @@ export function BigIntReader(stream, factory) {
 
   const result = readDigitsWithUnderscores(stream, startPos);
   if (!result) return null;
-  let { value, underscoreSeen, lastUnderscore } = result;
+  let value = finalizeUnderscoredDigits(stream, startPos, result);
+  if (value === null) return null;
   ch = stream.current();
-
-  if (lastUnderscore) {
-    stream.setPosition(startPos);
-    return null;
-  }
-
-  if (underscoreSeen && value.startsWith('_')) {
-    stream.setPosition(startPos);
-    return null;
-  }
 
   if (ch !== 'n') {
     stream.setPosition(startPos);

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -1,4 +1,4 @@
-import { readDigitsWithUnderscores, isDigit } from './utils.js';
+import { readDigitsWithUnderscores, finalizeUnderscoredDigits, isDigit } from './utils.js';
 
 export function NumericSeparatorReader(stream, factory) {
   const startPos = stream.getPosition();
@@ -7,12 +7,8 @@ export function NumericSeparatorReader(stream, factory) {
 
   const result = readDigitsWithUnderscores(stream, startPos);
   if (!result) return null;
-  const { value, underscoreSeen, lastUnderscore } = result;
-
-  if (!underscoreSeen || lastUnderscore) {
-    stream.setPosition(startPos);
-    return null;
-  }
+  const value = finalizeUnderscoredDigits(stream, startPos, result, { require: true });
+  if (value === null) return null;
 
   const endPos = stream.getPosition();
   return factory('NUMBER', value, startPos, endPos);

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -93,6 +93,19 @@ export function readDigitsWithUnderscores(stream, mark) {
   return { value: join(buf), underscoreSeen, lastUnderscore };
 }
 
+/** Validate underscore usage for numeric literals */
+export function finalizeUnderscoredDigits(
+  stream,
+  mark,
+  { value, underscoreSeen, lastUnderscore },
+  { require = false } = {}
+) {
+  if (lastUnderscore) { stream.setPosition(mark); return null; }
+  if (underscoreSeen && value.startsWith('_')) { stream.setPosition(mark); return null; }
+  if (require && !underscoreSeen) { stream.setPosition(mark); return null; }
+  return value;
+}
+
 export function readDigits(stream) {
   const buf = [];
   while (isDigit(stream.current())) { buf.push(stream.current()); stream.advance(); }


### PR DESCRIPTION
## Summary
- deduplicate BigIntReader and NumericSeparatorReader underscore logic
- add `finalizeUnderscoredDigits` helper for validation

## Testing
- `yarn --silent lint`
- `yarn test`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_685a32e852b08331b7fbe05401944b80