### PR TITLE
[agent] refactor: unify numeric underscore parsing

### DIFF
--- a/src/lexer/BigIntReader.js
+++ b/src/lexer/BigIntReader.js
@@ -1,39 +1,12 @@
-import { readDigitsWithUnderscores, isDigit } from './utils.js';
+import { readNumericWithUnderscores, isDigit } from './utils.js';
 
 export function BigIntReader(stream, factory) {
   const startPos = stream.getPosition();
-  let ch = stream.current();
-  if (!isDigit(ch)) return null;
+  if (!isDigit(stream.current())) return null;
 
-  // verify there is a trailing 'n' so this is really a bigint
-  let idx = stream.index;
-  while (idx < stream.input.length && /[0-9_]/.test(stream.input[idx])) {
-    idx++;
-  }
-  if (stream.input[idx] !== 'n') return null;
-
-  const result = readDigitsWithUnderscores(stream, startPos);
+  const result = readNumericWithUnderscores(stream, startPos, { suffix: 'n' });
   if (!result) return null;
-  let { value, underscoreSeen, lastUnderscore } = result;
-  ch = stream.current();
 
-  if (lastUnderscore) {
-    stream.setPosition(startPos);
-    return null;
-  }
-
-  if (underscoreSeen && value.startsWith('_')) {
-    stream.setPosition(startPos);
-    return null;
-  }
-
-  if (ch !== 'n') {
-    stream.setPosition(startPos);
-    return null;
-  }
-
-  value += 'n';
-  stream.advance();
-  const endPos = stream.getPosition();
+  const { value, endPos } = result;
   return factory('BIGINT', value, startPos, endPos);
 }

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -1,19 +1,12 @@
-import { readDigitsWithUnderscores, isDigit } from './utils.js';
+import { readNumericWithUnderscores, isDigit } from './utils.js';
 
 export function NumericSeparatorReader(stream, factory) {
   const startPos = stream.getPosition();
-  let ch = stream.current();
-  if (!isDigit(ch)) return null;
+  if (!isDigit(stream.current())) return null;
 
-  const result = readDigitsWithUnderscores(stream, startPos);
+  const result = readNumericWithUnderscores(stream, startPos, { requireUnderscore: true });
   if (!result) return null;
-  const { value, underscoreSeen, lastUnderscore } = result;
 
-  if (!underscoreSeen || lastUnderscore) {
-    stream.setPosition(startPos);
-    return null;
-  }
-
-  const endPos = stream.getPosition();
+  const { value, endPos } = result;
   return factory('NUMBER', value, startPos, endPos);
 }


### PR DESCRIPTION
## Summary
- add `readNumericWithUnderscores` helper
- simplify bigint and numeric separator readers

## Testing
- `yarn lint`
- `yarn test`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_685a32e852b08331b7fbe05401944b80