### PR TITLE
[agent] refactor whitespace readers

### DIFF
--- a/src/lexer/UnicodeWhitespaceReader.js
+++ b/src/lexer/UnicodeWhitespaceReader.js
@@ -1,12 +1,7 @@
 // src/lexer/UnicodeWhitespaceReader.js
 
+import { createWhitespaceReader } from './utils.js';
+
 const WS_RE = /\p{White_Space}/u;
 
-export function UnicodeWhitespaceReader(stream, factory) {
-  const start = stream.getPosition();
-  if (!WS_RE.test(stream.current() || '')) return null;
-
-  const buf = [];
-  while (!stream.eof() && WS_RE.test(stream.current())) { buf.push(stream.current()); stream.advance(); }
-  return factory('WHITESPACE', buf.join(''), start, stream.getPosition());
-}
+export const UnicodeWhitespaceReader = createWhitespaceReader(ch => WS_RE.test(ch || ''));

--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -1,11 +1,6 @@
 // src/lexer/WhitespaceReader.js          (rewritten ✨)
-const WS = new Set([' ','\n','\t','\r','\v','\f']);
+import { createWhitespaceReader } from './utils.js';
 
-export function WhitespaceReader(stream, factory) {
-  const start = stream.getPosition();
-  if (!WS.has(stream.current())) return null;
+const WS = new Set([' ', '\n', '\t', '\r', '\v', '\f']);
 
-  const buf = [];
-  while (!stream.eof() && WS.has(stream.current())) { buf.push(stream.current()); stream.advance(); }
-  return factory('WHITESPACE', buf.join(''), start, stream.getPosition());
-}
+export const WhitespaceReader = createWhitespaceReader(ch => WS.has(ch));

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -1,5 +1,5 @@
 // ────────────────────────────────────────────────────────────
-// src/lexer/utils.js 
+// src/lexer/utils.js
 // ────────────────────────────────────────────────────────────
 
 /* ── generic helpers ──────────────────────────────────────── */
@@ -135,5 +135,19 @@ export function makeIdentifierReader({ unicode = false, allowEscape = false, bai
     const value = consumeIdentifierLike(stream, { unicode, allowEscape });
     if (value === null) return null;
     return factory('IDENTIFIER', value, start, stream.getPosition());
+  };
+}
+
+/** Factory to create whitespace readers */
+export function createWhitespaceReader(testFn) {
+  return function whitespaceReader(stream, factory) {
+    const start = stream.getPosition();
+    if (!testFn(stream.current())) return null;
+    const buf = [];
+    while (!stream.eof() && testFn(stream.current())) {
+      buf.push(stream.current());
+      stream.advance();
+    }
+    return factory('WHITESPACE', buf.join(''), start, stream.getPosition());
   };
 }


### PR DESCRIPTION
## Summary
- reduce duplication by adding `createWhitespaceReader`
- refactor `WhitespaceReader` and `UnicodeWhitespaceReader` to use the new helper

## Testing
- `yarn lint`
- `yarn test --silent`
- `node src/utils/diagnostics.js "foo |> bar"`

------
https://chatgpt.com/codex/tasks/task_e_685a32e852b08331b7fbe05401944b80