### PR TITLE
[agent] automate simple token readers

### DIFF
--- a/src/lexer/BindOperatorReader.js
+++ b/src/lexer/BindOperatorReader.js
@@ -1,10 +1,3 @@
-export function BindOperatorReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.current() === ':' && stream.peek() === ':') {
-    stream.advance();
-    stream.advance();
-    const endPos = stream.getPosition();
-    return factory('BIND_OPERATOR', '::', startPos, endPos);
-  }
-  return null;
-}
+import { createLiteralReader } from './readerFactory.js';
+
+export const BindOperatorReader = createLiteralReader('BIND_OPERATOR', '::');

--- a/src/lexer/ByteOrderMarkReader.js
+++ b/src/lexer/ByteOrderMarkReader.js
@@ -1,8 +1,7 @@
-export function ByteOrderMarkReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.index !== 0) return null;
-  if (stream.current() !== '\uFEFF') return null;
-  stream.advance();
-  const endPos = stream.getPosition();
-  return factory('BOM', '\uFEFF', startPos, endPos);
-}
+import { createLiteralReader } from './readerFactory.js';
+
+export const ByteOrderMarkReader = createLiteralReader(
+  'BOM',
+  '\uFEFF',
+  { requireStart: true }
+);

--- a/src/lexer/FunctionSentReader.js
+++ b/src/lexer/FunctionSentReader.js
@@ -1,27 +1,7 @@
-export function FunctionSentReader(stream, factory) {
-  const startPos = stream.getPosition();
-  const prevIndex = startPos.index - 1;
-  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
-  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+import { createLiteralReader } from './readerFactory.js';
 
-  const seq = 'function.sent';
-  if (!stream.input.startsWith(seq, startPos.index)) return null;
-
-  const saved = stream.getPosition();
-  for (const ch of seq) {
-    if (stream.current() !== ch) {
-      stream.setPosition(saved);
-      return null;
-    }
-    stream.advance();
-  }
-
-  const next = stream.current();
-  if (next && /[A-Za-z0-9_$]/.test(next)) {
-    stream.setPosition(saved);
-    return null;
-  }
-
-  const endPos = stream.getPosition();
-  return factory('FUNCTION_SENT', seq, startPos, endPos);
-}
+export const FunctionSentReader = createLiteralReader(
+  'FUNCTION_SENT',
+  'function.sent',
+  { checkPrev: true, checkNext: true }
+);

--- a/src/lexer/PipelineOperatorReader.js
+++ b/src/lexer/PipelineOperatorReader.js
@@ -1,14 +1,9 @@
 // src/lexer/PipelineOperatorReader.js
 
-export function PipelineOperatorReader(stream, factory) {
-  const startPos = stream.getPosition();
+import { createLiteralReader } from './readerFactory.js';
 
-  // “|>” must be contiguous – no whitespace is permitted inside the token.
-  if (stream.current() === '|' && stream.peek() === '>') {
-    stream.advance(); // '|'
-    stream.advance(); // '>'
-    const endPos = stream.getPosition();
-    return factory('PIPELINE_OPERATOR', '|>', startPos, endPos);
-  }
-  return null;
-}
+// “|>” must be contiguous – no whitespace is permitted inside the token.
+export const PipelineOperatorReader = createLiteralReader(
+  'PIPELINE_OPERATOR',
+  '|>'
+);

--- a/src/lexer/readerFactory.js
+++ b/src/lexer/readerFactory.js
@@ -1,0 +1,37 @@
+export function createLiteralReader(
+  tokenType,
+  literal,
+  {
+    requireStart = false,
+    checkPrev = false,
+    checkNext = false
+  } = {}
+) {
+  const chars = [...literal];
+  return function literalReader(stream, factory) {
+    const start = stream.getPosition();
+    if (requireStart && stream.index !== 0) return null;
+
+    if (checkPrev) {
+      const prevIdx = start.index - 1;
+      const prev = prevIdx >= 0 ? stream.input[prevIdx] : null;
+      if (prev && /[A-Za-z0-9_$]/.test(prev)) return null;
+    }
+
+    for (const ch of chars) {
+      if (stream.current() !== ch) {
+        stream.setPosition(start);
+        return null;
+      }
+      stream.advance();
+    }
+
+    if (checkNext && /[A-Za-z0-9_$]/.test(stream.current() || '')) {
+      stream.setPosition(start);
+      return null;
+    }
+
+    const end = stream.getPosition();
+    return factory(tokenType, literal, start, end);
+  };
+}


### PR DESCRIPTION
## Summary
- add boundary options to `createLiteralReader`
- refactor `FunctionSentReader` to use the new helper

## Testing
- `yarn lint`
- `yarn test --silent --coverage`
- `node src/utils/diagnostics.js "foo |> bar"`


------
https://chatgpt.com/codex/tasks/task_e_685a5c303e248331890a668cff0b9241